### PR TITLE
📝Fix github username

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -12,7 +12,7 @@ jobs:
         DOCKER_TAG=`git rev-parse --short HEAD`;
         docker build . --file Dockerfile --build-arg VCS_REF="$DOCKER_TAG" --tag "docker.pkg.github.com/$DOCKER_REPO/wiki:$DOCKER_TAG"
     - name: Login to Docker Registry
-      run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username beat-saber-modding-group --password-stdin
+      run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username bsmg --password-stdin
     - name: Push to Docker Registry
       run: |
         DOCKER_REPO=`echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]'`;


### PR DESCRIPTION
Updated the github action because the BSMG org is finally named `bsmg` not `beat-saber-modding-group` !