### PR TITLE
:arrow_up: Upgrading WUT

### DIFF
--- a/.github/workflows/wiki-update-tracker.yml
+++ b/.github/workflows/wiki-update-tracker.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check original pages status and update issues
         if: env.ENABLE == '1ENABLED'
-        uses: Awagi/wiki-update-tracker@v1.5
+        uses: Awagi/wiki-update-tracker@v1.6
         with:
           repo-path: $GITHUB_WORKSPACE
           original-path: "wiki"
@@ -42,5 +42,6 @@ jobs:
           bot-label: "BOT"
           token: ${{ steps.get_token.outputs.app_token }}
           log-level: "DEBUG"
+          auto-create: "1"
     env:
         ENABLE: ${{ secrets.ENABLE_WUT }}

--- a/.github/workflows/wiki-update-tracker.yml
+++ b/.github/workflows/wiki-update-tracker.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check original pages status and update translation Projects
         if: env.ENABLE == '1ENABLED'
-        uses: Awagi/wiki-update-tracker@v1.7
+        uses: Awagi/wiki-update-tracker@v1.7.1
         with:
           repo-path: $GITHUB_WORKSPACE
           original-path: "wiki"

--- a/.github/workflows/wiki-update-tracker.yml
+++ b/.github/workflows/wiki-update-tracker.yml
@@ -30,18 +30,20 @@ jobs:
           APP_PEM: ${{ secrets.APP_PEM }}
           APP_ID: ${{ secrets.APP_ID }}
 
-      - name: Check original pages status and update issues
+      - name: Check original pages status and update translation Projects
         if: env.ENABLE == '1ENABLED'
-        uses: Awagi/wiki-update-tracker@v1.6
+        uses: Awagi/wiki-update-tracker@v1.7
         with:
           repo-path: $GITHUB_WORKSPACE
           original-path: "wiki"
           ignored-paths: "wiki/LICENSE,wiki/.vuepress"
-          translation-paths: "wiki/fr"
+          translations: "fr:wiki/fr"
           file-suffix: ".md"
           bot-label: "BOT"
           token: ${{ steps.get_token.outputs.app_token }}
           log-level: "DEBUG"
           auto-create: "1"
+          update-issues: "0"
+          update-projects: "1"
     env:
         ENABLE: ${{ secrets.ENABLE_WUT }}


### PR DESCRIPTION
The **Wiki Update Tracker** bot can now automatically **create non-existing translation pages**, marking it as stub and requiring an initialization. It will be useful:
- to create the whole structure automatically, when adding new language
- to avoid random 404 on the website when a new original page is created and no translation page in the dedicated language do not exist

The feature can be disabled setting the input **`auto-create`** to **`0`** in the `wiki-update-tracker` workflow. _Merging this PR will enable it._

It **does not** require new permission from its dedicated Github App as it does not use Github API. Instead, it uses git commit and pushes on master, so it's all handled within the workflow.
Note that pushes produced by a job in Github Actions do not trigger jobs again, fortunately.

Some **results** can be seen on my [test branch](https://github.com/Awagi/wiki/tree/test-wut) (see `de` new folder and a new page in `fr` folder), as well as [issues](https://github.com/Awagi/wiki/issues), which didn't change much.

[Here's the comparison](https://github.com/Awagi/wiki-update-tracker/compare/v1.5...v1.6) for code reviewers between current and latest version.

I first thought about making automated PR rather than directly pushing files but it wouldn't be convenient as it would have required human validation...