### PR TITLE
WUT v1.8

### DIFF
--- a/.github/workflows/wiki-update-tracker.yml
+++ b/.github/workflows/wiki-update-tracker.yml
@@ -46,6 +46,7 @@ jobs:
             *.md
           stub-template: .github/workflows/wut-templates/translation-stub-template.md
           gen-branch: wut-branch
+          request-merge: true
           gen-copy: |-
             *.png
           token: ${{ steps.get_token.outputs.app_token }}

--- a/.github/workflows/wiki-update-tracker.yml
+++ b/.github/workflows/wiki-update-tracker.yml
@@ -32,18 +32,31 @@ jobs:
 
       - name: Check original pages status and update translation Projects
         if: env.ENABLE == '1ENABLED'
-        uses: Awagi/wiki-update-tracker@v1.7.1
+        uses: Awagi/wiki-update-tracker@v1.8.0
         with:
-          repo-path: $GITHUB_WORKSPACE
-          original-path: "wiki"
-          ignored-paths: "wiki/LICENSE,wiki/.vuepress"
-          translations: "fr:wiki/fr"
-          file-suffix: ".md"
-          bot-label: "BOT"
-          token: ${{ steps.get_token.outputs.app_token }}
           log-level: "DEBUG"
-          auto-create: "1"
-          update-issues: "0"
-          update-projects: "1"
+          repo-path: "."
+          original: "wiki"
+          translations: |-
+            fr:wiki/fr
+          filters: "**/*"
+          ignores: |-
+            wiki/LICENSE
+          gen-stubs: |-
+            *.md
+          stub-template: .github/workflows/wut-templates/translation-stub-template.md
+          gen-branch: wut-branch
+          gen-copy: |-
+            *.png
+          token: ${{ steps.get_token.outputs.app_token }}
+          instruct-projects: |-
+            *.md
+          project-title-template: "Wiki {t.translation.language} Update Tracker"
+          project-description-template: "{t.translation.language} translation effort."
+          project-card-create-template: .github/workflows/wut-templates/project-create-template.md
+          project-card-initialize-template: .github/workflows/wut-templates/project-initialize-template.md
+          project-card-update-template: .github/workflows/wut-templates/project-update-template.md
+          project-card-uptodate-template: .github/workflows/wut-templates/project-uptodate-template.md
+          project-card-orphan-template: .github/workflows/wut-templates/project-orphan-template.md
     env:
         ENABLE: ${{ secrets.ENABLE_WUT }}

--- a/.github/workflows/wut-templates/project-create-template.md
+++ b/.github/workflows/wut-templates/project-create-template.md
@@ -1,0 +1,8 @@
+**:hammer_and_pick: :warning: `{t.translation.path}`** using:
+* **[The original file](<{original_url}>)**
+  * Use *Raw* for better accuracy
+
+**`{t.original.path}`** contains:
+```diff
++ {t.missing_lines} lines
+```

--- a/.github/workflows/wut-templates/project-initialize-template.md
+++ b/.github/workflows/wut-templates/project-initialize-template.md
@@ -1,0 +1,8 @@
+**:warning: [`{t.translation.path}`](<{translation_url}>)** using:
+* **[The original file](<{original_url}>)**
+  * Use *Raw* for better accuracy
+
+**`{t.original.path}`** contains:
+```diff
++ {t.missing_lines} lines
+```

--- a/.github/workflows/wut-templates/project-orphan-template.md
+++ b/.github/workflows/wut-templates/project-orphan-template.md
@@ -1,0 +1,8 @@
+**:recycle: [`{t.translation.path}`](<{translation_url}>)**:
+- to move or rename?
+- to delete?
+
+**`{t.translation.path}`** contains:
+```diff
+! {t.surplus_lines} lines
+```

--- a/.github/workflows/wut-templates/project-update-template.md
+++ b/.github/workflows/wut-templates/project-update-template.md
@@ -1,0 +1,12 @@
+**:pencil: [`{t.translation.path}`](<{translation_url}>)** using:
+* **[Github comparison](<{compare_url}>)**
+  * Comparison on **`{t.original.path}`**
+* or **[Diffchecker web](https://www.diffchecker.com)**
+  * [Old original content](<{raw_base_original_url}>)
+  * [Recent original content](<{raw_original_url}>)
+
+**`{t.original.path}`** changes:
+```diff
++ {t.patch.additions} lines
+- {t.patch.deletions} lines
+```

--- a/.github/workflows/wut-templates/project-uptodate-template.md
+++ b/.github/workflows/wut-templates/project-uptodate-template.md
@@ -1,0 +1,1 @@
+:heavy_check_mark: **`{t.translation.path}`** is up-to-date!

--- a/.github/workflows/wut-templates/translation-stub-template.md
+++ b/.github/workflows/wut-templates/translation-stub-template.md
@@ -1,0 +1,11 @@
+---
+translation-done: false
+---
+::: danger
+Sorry, this page has not been translated yet, you can either:
+- refer to the [original English version](<{translation_to_original_path}>),
+- wait for a translation to be done,
+- or contribute to translation effort [here](https://github.com/bsmg/wiki).
+:::
+
+_Note for translators: this page was generated automatically, please remove this content before starting translation_


### PR DESCRIPTION
![Wiki Update Tracker](https://github.com/Awagi/wiki/workflows/Wiki%20Update%20Tracker/badge.svg?branch=test-wut)

Hey, so there's a new version of WUT. New features are:
- it tracks **orphan translations**. A new column "Orphans" in the Project is set when finding one. It's useful if a `.md` page or a `.png` image is removed in the EN directory. Note that when an original file is renamed, its corresponding translation files are considered "To update", not "Orphan".
- it can make stub translation pages in **another branch** (`wut-branch` as of current input in the workflow).
- it can **copy files** when they have to be created, just like stubs, but adapted for images for example.
- it **creates a Pull request** when changes are made in the dedicated branch, so we can review manually stubs and copies.
- templates can be changed directly in workflow, or in files for Project cards.

Pre-requisites for this new version:
1) the dedicated GitHub App must have **Pull requests read/write permission**, otherwise no pull request will be created when files are copied or stubs are made.
2) the branch `wut-branch` must exist initially. Also, leave this one to WUT as it will reset it to master's head at every run with copies and stubs.

Note that v1.8 jobs should take longer than v1.7 to run now that orphan translations and images/videos are tracked.
Also, backend was reworked so it is much more reliable and maintainable, but that's another story.

It passed my test repo: https://github.com/Awagi/wiki/actions/runs/165840662

Technical differences in code for nerds: https://github.com/Awagi/wiki-update-tracker/compare/v1.7.1...v1.8.0
