### PR TITLE
Don't copy images

### DIFF
--- a/.github/workflows/wiki-update-tracker.yml
+++ b/.github/workflows/wiki-update-tracker.yml
@@ -48,8 +48,6 @@ jobs:
           stub-template: .github/workflows/wut-templates/translation-stub-template.md
           gen-branch: wut-branch
           request-merge: true
-          gen-copy: |-
-            *.png
           token: ${{ steps.get_token.outputs.app_token }}
           instruct-projects: |-
             *.md


### PR DESCRIPTION
The idea was to have images in every translation folders to have it translated when required (if the image contains text or another part to localize), but it's definitely unoptimized and isn't done yet.