### PR TITLE
Update to add Qosmetics Community instead of BMBF on Custom Sabers page

### DIFF
--- a/wiki/models/custom-sabers.md
+++ b/wiki/models/custom-sabers.md
@@ -1,6 +1,6 @@
 # Custom Sabers
 ## Installation
-If you are on PC, the latest Custom Saber plugin can be found in the [#pc-mods channel](https://discord.gg/beatsabermods) in the BSMG discord or in [Mod Assistant](https://github.com/Assistant/ModAssistant). If you are on the quest, the custom sabers mod can be found on [BMBF](https://bsmg.wiki/quest-modding.html). Run ModAssistant, select the Custom Saber plugin, and click Install.
+If you are on PC, the latest Custom Saber plugin can be found in the [#pc-mods channel](https://discord.gg/beatsabermods) in the BSMG discord or in [Mod Assistant](https://github.com/Assistant/ModAssistant). If you are on the quest, the custom sabers mod can be found in the [Qosmetics Community discord](https://discord.gg/MEBVngG). Run ModAssistant, select the Custom Saber plugin, and click Install.
 Once you've installed it you will see a folder called `CustomSabers` in [your install folder](/faq/install-folder.md), this is where you should place the `*.saber` files you want to use. 
 
 You can download more sabers on [ModelSaber](https://modelsaber.com/Sabers/).


### PR DESCRIPTION
Nobody ever uses asset swaps anymore, so linking to the Qosmetics community as a place to get sabers would be helpful for the quest section of this page.