### PR TITLE
Basic Audio Restructure

### DIFF
--- a/wiki/mapping/advanced-audio.md
+++ b/wiki/mapping/advanced-audio.md
@@ -41,7 +41,7 @@ To know what level is ideal for your song you can export your track with differe
 
 You can’t increase audio quality by saving a lossy track with a higher bitrate (e.g. saving a YouTube-sourced track with level 10 quality), you will only bloat the file size. As explained in the previous chapter, information is lost when transcoding to any lossy format and thus can’t be restored. Transcoding one lossless format to another lossless format is fine though, e.g. FLAC to WAV(E).
 
-## Explaning Audio Processing
+## Explaining Audio Processing
 To work with audio and do processing of the soundwaves there are several tools available to help achieve what we want or need. Two of these tools used are *Compressor* and *Limiter* which we used for volume processing in [Volume Modification: Making Your Song Louder](/mapping/basic-audio.md#making-your-song-louder). Below these tools are explained in more detail:
 
 ### Compressor

--- a/wiki/mapping/basic-audio.md
+++ b/wiki/mapping/basic-audio.md
@@ -13,19 +13,19 @@ This page provides both new and experienced mappers with general recommendations
 
 ## Audio Setup Quick Start
 ::: warning
-* Steps 1-5 **MUST** be completed before you start mapping or your audio will be out of sync and may have a [*hot start*](./glossary.html#h).
+* Steps 1-3 **MUST** be completed before you start mapping or your audio will be out of sync and may have a [*hot start*](./glossary.html#h).
 
 * Using Online Websites to convert audio to `.ogg` may result in your audio file being treated as invalid and will not be loaded by the game! Processing and exporting from [Audacity](https://www.audacityteam.org/) is the easiest way to ensure your audio file works as expected.
 :::
+
 1. Download and Install [Audacity](https://www.audacityteam.org/)
 	* Optionally install the [ffmpeg for windows](https://manual.audacityteam.org/man/installing_ffmpeg_for_windows.html) addon to open additional file types such as `.aac` or `.m4a` from iTunes.
-2. [Find the BPM](./basic-audio.html#finding-the-bpm) and offset of your song
-3. [Add a click track](./basic-audio.html#add-a-click-track) to verify your BPM and [sync your song](./basic-audio.html#sync-the-song-to-the-beat)
-4. Figure out if you have [enough intro/silence](./basic-audio.html#plan-your-first-note) at the start of your song and [add silence](./basic-audio.html#add-silence)
-5. Remove your click track then [Export your song](./basic-audio.html#exporting) as an `.ogg` format file
+2. Find the BPM and offset of your song to [sync your song](./basic-audio.html#syncing-audio)
+3. [Export your song](./basic-audio.html#exporting) as an `.ogg` format file
 
 **Any time before upload:**  
-6. [Check your song volume](./basic-audio.html#check-song-volume) and make it [louder](./basic-audio.html#making-your-song-louder) or [softer](./basic-audio.html#making-your-song-softer) as needed
+4. [Check your song volume](./basic-audio.html#check-song-volume) and make it [louder](./basic-audio.html#making-your-song-louder) or [softer](./basic-audio.html#making-your-song-softer) as needed  
+5. Check the length of your song outro and [trim it](./basic-audio.html#trimming-the-audio) if needed
 
 ## Song Selection for New Mappers
 Below are recommendations, **not** requirements, and will help to ease you into mapping. If you want to map 17 minutes of "In A Gadda Da Vida" for your first map then have at it but know that you’ll face a **lot** of additional challenges.
@@ -41,7 +41,7 @@ Before you begin mapping, ensure you have a high quality source file for your so
 Follow these general guidelines as you work on your maps:
 * Use the highest quality source you can find such as **FLAC or WAV(E)** files (lossless format).
 * A close second are high bitrate (+200kbps) **MP3 or AAC** files (lossy formats). 
-* Use a YouTube rip **only** as a last resort. The bitrate is low and the volume is seldom right. In this case some audio editing might be required (see [Editing with Audacity](/mapping/basic-audio.html#editing-with-audacity)).
+* Use a YouTube rip **only** as a last resort. The bitrate is low and the volume is seldom right. In this case some audio editing might be required (see [Optional Audio Editing](/mapping/basic-audio.html#optional-audio-editing)).
 
 > Sites where you can buy the tracks/album, such as an artist’s [Bandcamp](https://bandcamp.com/), usually will have the highest quality source available. If the artist does not have a Bandcamp available, Google Play Music, Amazon Music and iTunes are alternatives for high quality MP3 files.
 
@@ -57,13 +57,27 @@ Can you see the difference? You cannot scale up audio quality; only starting wit
 
 See the [Advanced Audio Editing](/mapping/advanced-audio.md) page for more in-depth techniques and tools for analysing the audio quality of files.
 
-## Finding the BPM
-There are three ways to find the BPM for the song which you want to map. Try them in order (easiest to hardest) if you don't get any results:
 
-### Tool-Assisted BPM Calculation
-::: tip NOTE   
-This is the recommended method for songs with a constant BPM.
-:::
+## Syncing Audio
+
+To make it easier to map and make sure that the song is synced perfectly to the game's beat you need to set up your audio file correctly. This section will assume you are using [Audacity](https://www.audacityteam.org/).
+
+### Plan Your First Note
+Analyse the intro of the song. Depending on where in the song you want to place your first block, you'll need to avoid both a *hot start* (not enough time before the first block) and a too-long intro. Your song will fit into one of three categories:
+1. **Songs with no intro:** It is critical to leave at **minimum two seconds** of preparation time for the player before the first playable note(s) in your map, otherwise this is known as a "Hot Start."
+2. **Songs with a short intro:** If your song has a short intro that is **less than eight seconds** it is OK for the music to start playing immediately.
+3. **Songs with a long intro:** If the song has a very long and uneventful/fade-in intro for **more than ten seconds** it is strongly recommended to shorten the intro so the first note(s) are placed within eight seconds from map start.
+
+In all cases above you will need to time shift the song to an appropriate time based on your needs:
+1. **No intro:** Move the song back in time (to the right in the audio track), placing the first mapped note(s) after two seconds. Then sync the song to the beat. Later fill the gap with silence.
+2. **Short Intro:** Sync the song to the beat and then fill the gap with silence depending on which case applies.
+3. **Long intro:** Move the song forward in time (to the left in the audio track), placing the first note(s) within 8 seconds, then trim the audio before 0 seconds.
+
+There are two ways to sync your audio:
+* The recommended method for syncing songs is by [using Arrow Vortex](./basic-audio.html#sync-using-arrow-vortex).
+* The alternative method for syncing songs is by manually doing it [using a Click Track](./basic-audio.html#sync-using-a-click-track).
+
+### Sync using Arrow Vortex
 
 [Arrow Vortex](https://arrowvortex.ddrnl.com/) is a free tool to analyze a song’s BPM automatically. It will also find the offset needed to line the audio up to the beat in Audacity or your map editor. 
 
@@ -104,83 +118,9 @@ If you have the experience, see [Advanced Audio Editing: Variable BPM](/mapping/
 
 10. Give the player about two seconds to get ready by clicking the `Move first beat` button ![Arrow Vortex move beat button](~@images/mapping/av_movebeat.png) however many times needed to get your start time close to 2.000 seconds or the sound you want to place your first note on aligned with the first bar.  
 ![Aligned with first bar](~@images/mapping/av_aligned.png) ![Alternate Aligned with first bar](~@images/mapping/av_altAligned2.png)
-	* After aligning, you should check the song again to verify that the beats still match.
-	* If your song has too much intro silence, you will end up with a negative `Music offset`. What this means is that you will need to remove silence from intro of the audio file in Audacity. If you are not comfortable with removing the exact amount, you can remove more than needed, export the change `.ogg` and re-sync with the new file to get a positive offset.
-11. After finding the BPM and offset values you can skip to [Add Silence: After Tool Assisted Sync](/mapping/basic-audio.html#after-tool-assisted-sync).
-
-### Online Search
-You can search online using a search engine site (e.g. [Google](http://google.com)) in your web browser for `[song name] + [artist] + "bpm"` and often find a number of sites (e.g. [SongBPM.com](https://songbpm.com/)) with this information.
-
-### Manual BPM Calculation
-If both methods above fail you will have to manually find the BPM, but this is easier than you might think.
-1. Use an online BPM tapping calculator (like the [Tap for BPM Tool](https://www.all8.com/tools/bpm.htm), open the page in your web browser).
-2. Play the song in your favorite music player.
-3. With the webpage in focus, tap any key to the beat (every quarter note) for about 30 seconds and the tool will display the BPM of the song.
-4. Take note of the nearest whole value.
-
-## Audio Preparation
-To make it easier to map and make sure that the song is synced perfectly to the game's beat you need to set up your audio file correctly. This section will assume you are using [Audacity](https://www.audacityteam.org/).
-If you have used [Tool Assisted BPM](/mapping/basic-audio.html#tool-assisted-bpm-calculation) and offset detection (such as Arrow Vortex) you can skip to [Add Silence: After Tool Assisted Sync](/mapping/basic-audio.html#after-tool-assisted-sync).
-
-### Plan Your First Note
-Analyse the intro of the song. Depending on where in the song you want to place your first block, you'll need to avoid both a *hot start* (not enough time before the first block) and a too-long intro. Your song will fit into one of three categories:
-1. **Songs with no intro:** It is critical to leave at **minimum two seconds** of preparation time for the player before the first playable note(s) in your map, otherwise this is known as a "Hot Start."
-2. **Songs with a short intro:** If your song has a short intro that is **less than eight seconds** it is OK for the music to start playing immediately.
-3. **Songs with a long intro:** If the song has a very long and uneventful/fade-in intro for **more than ten seconds** it is strongly recommended to shorten the intro so the first note(s) are placed within eight seconds from map start.
-
-In all cases above you will need to time shift the song to an appropriate time based on your needs:
-1. **No intro:** Move the song back in time (to the right in the audio track), placing the first mapped note(s) after two seconds. Then sync the song to the beat (See [Sync the Song to the Beat](/mapping/basic-audio.html#sync-the-song-to-the-beat)). Later fill the gap with silence (See [Add Silence](/mapping/basic-audio.html#add-silence)).
-2. **Short Intro:** Sync the song to the beat (See [Sync the Song to the Beat](/mapping/basic-audio.html#sync-the-song-to-the-beat)) and then fill the gap with silence (See [Add Silence](/mapping/basic-audio.html#add-silence)) or trim the audio before 0 seconds (See [Trim the Intro](/mapping/basic-audio.html#trim-the-intro)) depending on which case applies.
-3. **Long intro:** Move the song forward in time (to the left in the audio track), placing the first note(s) within 8 seconds (See [Sync the Song to the Beat](/mapping/basic-audio.html#sync-the-song-to-the-beat)), then trim the audio before 0 seconds (See [Trim the Intro](/mapping/basic-audio.html#trim-the-intro)).
-
-### Add a Click Track
-This is to confirm that the BPM you have found online or manually matches the audio file you have. This addition is temporary; you should remove the click track before [exporting your audio](/mapping/basic-audio.html#exporting).
-1. Open the song you want to map into Audacity.
-2. Add a new mono track from `Tracks menu > Add New > Mono Track`
-3. Place the cursor at the start of the new track (Click on the track and press your Home key) and then click `Generate menu > Rhythm Track…`
-4. Input the nearest whole BPM you got earlier into the `Tempo (bpm)` field and enter the duration of the song in the optional `Rhythm track duration` field (the duration is displayed at the top right of the timeline).
-5. Copy the other recommended settings below:
-![Audacity Rhythm Track Menu](~@images/mapping/click-track-1.png)
-
-If everything was correctly input you will have something like this:
-![Audacity main screen showing song track and rhythm track](~@images/mapping/song_rhythm.png)
-
-This click track is completely in sync with the beats in the map editor and game, but the song is currently not synced. Continue below for how to do that.
-
-### Sync the Song to the Beat
-1. Select the Time Shift Tool (![Time Shift Tool](~@images/mapping/timeshift.png)).
-2. Left click on the song track and hold, then drag the audio so that the first planned mapped note(s) in your song ends up within the appropriate seconds (see timeline above the track) to avoid a "Hot Start" or too long intro (See [Plan Your First Notes](/mapping/basic-audio.html#plan-your-first-note) if you haven’t already).
-3. Release to place the audio in the new position.
-4. Play back the audio in this position. The song will be out of sync, so find the closest beat in the click track and align your song to the beat (click track) by moving it backward or forwards in time by small increments. Zoom in for better accuracy. Repeat until it sounds spot on.
-5. When you think you’ve found the beats of the song to match the Click Track review the whole song to ensure that the BPM you have is the correct one and that the song is in the same fixed BPM throughout the whole song. If not, you might have gotten the wrong BPM, in which case try to tap out the BPM manually (again), see "Manual BPM Calculation". 
-::: warning
-If the BPM is correct for the first part of the song but suddenly change or drifts off then you most likely have a song with Variable BPM, see [Advanced Audio Editing: Variable BPM](/mapping/advanced-audio.html#variable-bpm) for more info on this subject.
-:::
-
-Below shows how it looks like when the first planned mapped note(s) (cursor position) are placed after 2 seconds and the beats of the song is synced to the BPM/Click Track.
-![Audacity song lined up with rhythm track](~@images/mapping/synced_rhythm.png)
-After time shifting the song you will need to add silence, continue below on how to do that.
-
-## Editing with Audacity
-After syncing the song to the beat manually or by using tool assisted sync (e.g. Vortex Arrow) you will have to add silence to the intro of the song. You may also need to do other edits if they’re necessary. More on that below.
-
-### Add Silence
-#### After manual sync:
-If the waveform/audio clip has a gap to the timeline start (0,0 seconds) you will need to add silence to the audio, or else Audacity will export from the start of the audio clip and you will lose any sync you've done. Do the following to add silence:
-1. Switch to the Selection Tool (![Selection Tool](~@images/mapping/selection.png)).
-2. Select the empty space between the audio clip and the start of the track (Yellow vertical lines will indicate the start and end edges when you make a selection).  
-![Adding silence with Audacity](~@images/mapping/add_silence.png)
-3. Click `Generate menu – > Silence…`  
-![Generate Silence...](~@images/mapping/audacity-generate_silence.png)
-4. The right amount of silence should already be input automagically so just hit OK.
-5. Done.
-
-
-After generating the silence you can click the dark line in the song track to get rid of the cut.
-
-#### After tool assisted sync:
-If you've used Arrow Vortex or other tool assisted syncing then do the following to add or remove the right amount of silence to the song track.
-
+	* After aligning, you should check the song again to verify that the beats still match.  
+11. Now that you have the BPM and offset, you will need to add or remove the right amount of silence to the song track.  
+___
 **If you have a positive offset**, you will need to add that amount to the intro.  
 1. Open the song in Audacity if you haven't already done so, then switch to the Selection Tool (![Selection Tool](~@images/mapping/selection.png)).
 2. Place the cursor at the start of the song track (Click on the song track and press your <kbd>Home</kbd> key).
@@ -188,7 +128,9 @@ If you've used Arrow Vortex or other tool assisted syncing then do the following
 ![Generate Silence...](~@images/mapping/audacity-generate_silence.png)
 4. Input the sync `Music offset` value you got from Arrow Vortex (or similar tool) and then click OK. 
 ![Adding silence with Audacity](~@images/mapping/av_audacity.png)
-5. Done.  
+5. Done. You can now skip to [exporting](/mapping/basic-audio.html#exporting) or go to [optional audio editing](/mapping/basic-audio.html#optional-audio-editing).  
+
+After generating the silence you can click the dark line in the song track to get rid of the cut.
 ___
 **If you have a negative offset**, you will need to remove that amount from the intro.  
 1. Open the song in Audacity if you haven't already done so, then switch to the Selection Tool (![Selection Tool](~@images/mapping/selection.png)).
@@ -206,25 +148,62 @@ ___
 7. Press the <kbd>Delete</kbd> key.
 8. Click the X on the newest track to delete it.  
 ![Delete The Track](~@images/mapping/audacity-delete_track.png)
-9. Done.
+9. Done. You can now skip to [exporting](/mapping/basic-audio.html#exporting) or go to [optional audio editing](/mapping/basic-audio.html#optional-audio-editing).
 
-> If you are not comfortable with removing the exact amount, you can remove more than needed, export the change `.ogg` and [re-sync using your tool](#tool-assisted-bpm-calculation) with the new file to get a positive offset.
+> If you are not comfortable with removing the exact amount, you can remove more than needed, export the changed `.ogg` and [re-sync using your tool](#tool-assisted-bpm-calculation) with the new file to get a positive offset.
+
+### Sync using a Click Track
+
+#### Manual BPM Calculation
+If the method above fails you will have to manually find the BPM, but this is easier than you might think.
+1. Use an online BPM tapping calculator (like the [Tap for BPM Tool](https://www.all8.com/tools/bpm.htm), open the page in your web browser).
+2. Play the song in your favorite music player.
+3. With the webpage in focus, tap any key to the beat (every quarter note) for about 30 seconds and the tool will display the BPM of the song.
+4. Take note of the nearest whole value.
+
+#### Add a Click Track
+This is to confirm that the BPM you have found online or manually matches the audio file you have. This addition is temporary; you should remove the click track before [exporting your audio](/mapping/basic-audio.html#exporting).
+1. Open the song you want to map into Audacity.
+2. Add a new mono track from `Tracks menu > Add New > Mono Track`
+3. Place the cursor at the start of the new track (Click on the track and press your Home key) and then click `Generate menu > Rhythm Track…`
+4. Input the nearest whole BPM you got earlier into the `Tempo (bpm)` field and enter the duration of the song in the optional `Rhythm track duration` field (the duration is displayed at the top right of the timeline).
+5. Copy the other recommended settings below:
+![Audacity Rhythm Track Menu](~@images/mapping/click-track-1.png)
+
+If everything was correctly input you will have something like this:
+![Audacity main screen showing song track and rhythm track](~@images/mapping/song_rhythm.png)
+
+This click track is completely in sync with the beats in the map editor and game, but the song is currently not synced. Continue below for how to do that.
+
+#### Sync the Song to the Beat
+1. Select the Time Shift Tool (![Time Shift Tool](~@images/mapping/timeshift.png)).
+2. Left click on the song track and hold, then drag the audio so that the first planned mapped note(s) in your song ends up within the appropriate seconds (see timeline above the track) to avoid a "Hot Start" or too long intro (See [Plan Your First Notes](/mapping/basic-audio.html#plan-your-first-note) if you haven’t already).
+3. Release to place the audio in the new position.
+4. Play back the audio in this position. The song will be out of sync, so find the closest beat in the click track and align your song to the beat (click track) by moving it backward or forwards in time by small increments. Zoom in for better accuracy. Repeat until it sounds spot on.
+5. When you think you’ve found the beats of the song to match the Click Track review the whole song to ensure that the BPM you have is the correct one and that the song is in the same fixed BPM throughout the whole song. If not, you might have gotten the wrong BPM, in which case try to tap out the BPM manually (again), see "Manual BPM Calculation". 
+::: warning
+If the BPM is correct for the first part of the song but suddenly change or drifts off then you most likely have a song with Variable BPM, see [Advanced Audio Editing: Variable BPM](/mapping/advanced-audio.html#variable-bpm) for more info on this subject.
+:::
+
+Below shows how it looks like when the first planned mapped note(s) (cursor position) are placed after 2 seconds and the beats of the song is synced to the BPM/Click Track.
+![Audacity song lined up with rhythm track](~@images/mapping/synced_rhythm.png)
+
+If the waveform/audio clip has a gap to the timeline start (0,0 seconds) you will need to add silence to the audio, or else Audacity will export from the start of the audio clip and you will lose any sync you've done. Do the following to add silence:
+1. Switch to the Selection Tool (![Selection Tool](~@images/mapping/selection.png)).
+2. Select the empty space between the audio clip and the start of the track (Yellow vertical lines will indicate the start and end edges when you make a selection).  
+![Adding silence with Audacity](~@images/mapping/add_silence.png)
+3. Click `Generate menu – > Silence…`  
+![Generate Silence...](~@images/mapping/audacity-generate_silence.png)
+4. The right amount of silence should already be input automagically so just hit OK.
+5. Done. You can now skip to [exporting](/mapping/basic-audio.html#exporting) or go to [optional audio editing](/mapping/basic-audio.html#optional-audio-editing).
 
 After generating the silence you can click the dark line in the song track to get rid of the cut.
 
-### Trim the Intro
-This step is optional, but can be useful if you need to make a more graceful fade-in for your song, if needed.
-
-If your track has arrows pointing to the left at the start it means you’ve time shifted the audio forward in time outside the timeline. If you’ve done this to shorten the intro, although not necessary, it is beneficial to trim the sound clip and add a fade in. To trim and add a fade in to the song (optional) do the following:
-1. Drag a selection from 0.0 seconds to the end of the audio track (yellow vertical lines).
-2. Click Trim audio outside selection (![Trim audio to selection](~@images/mapping/trim.png)). The arrows should now disappear. 
-3. (Optional) Make a selection from track start (vertical yellow line) to about 0.5-1 seconds (depending on intro).
-4. (Optional) Go to `Effect menu -> Fade In`.
-5. Done.
-
-Before (left) and after trim and fade-in applied (right):
-
-![Trimming the song intro](~@images/mapping/trim_fade.png)
+## Optional Audio Editing
+At this point, your audio is set up and ready for [exporting](/mapping/basic-audio.html#exporting). Additional audio editing, while not necessary, can improve the player's experience by:
+* Ensuring the audio isn't too soft or too loud;
+* Ensuring the start of the audio is smooth; and
+* Ensuring the player doesn't have to wait too long for the outro to end.
 
 ### Check Song Volume
 To ensure that your song isn’t too soft, or even too loud for that matter, we can measure it using RMS (Root Mean Squared) in Audacity. To have a good balance between note slice sounds and your song the RMS value should be **louder than -11db** (in the verses and/or choruses) or **softer than -8.5db** (at the loudest parts).
@@ -254,7 +233,7 @@ To check if you need to apply Compressor before Limiter visually analyse the wav
 However, if the waveform varies a lot between soft and loud parts then compression will most likely be needed first.
 
 #### Compression
-1. Select the whole song track (Double click on the track)
+1. Select the whole song by double clicking the song track.
 2. Go to `Effects menu -> Compressor`
 3. As a starting point, copy the settings below and click OK. Make sure that `Compress based on Peaks` is checked.
 ![Understanding compression](~@images/mapping/compression.png)
@@ -267,7 +246,7 @@ Check the song again and listen for any unnatural distortions, such as volume cu
 
 #### Limiter
 The compressor reduces many of the unnecessary peaks and makes the more important sounds louder. However, we still haven’t reached the right RMS volume for the song. To achieve this we will remove more of the headroom using the Limiter effect:
-1. Select the whole song (Double click the song track)
+1. Select the whole song by double clicking the song track.
 2. Go to `Effects menu -> Limiter…`
 3. As a starting point, copy the settings below:  
 ![Limiter in Audacity](~@images/mapping/limiter.png)
@@ -283,7 +262,6 @@ To know if you’ve reached the right volume after compressing and limiting chec
 
 After limiting you will have something like this:
 ![Song after limiting](~@images/mapping/bna_limiting.png)
-You can now skip to [Trimming the Outro](/mapping/basic-audio.html#trimming-the-outro).
 
 
 #### Making Your Song Softer
@@ -297,8 +275,8 @@ Before you lower the volume you want to know approximately how much you need to 
 5. Close the Contrast Analysis window.
 
 Now let’s use the Amplify effect to lower the volume:
-1. Select the whole song (Double click the song track)
-2. Go to `Effects menu -> Amplify...`
+1. Select the whole song by double clicking the song track.
+2. Go to `Effects menu -> Amplify…`
 3. Enter the difference value you calculated earlier (it should be negative) into the `Amplification` field. `New Peak Amplification` field will repeat what the first input field says, this is normal for a song that is already peaking at 0db.   
 ![Amplification menu](~@images/mapping/amplify.png)
 4. Click OK to apply a negative Amplify effect.
@@ -313,8 +291,7 @@ To know if you’ve reached the right volume check again with the RMS volume too
 After the negative value Amplify effect your song will look something like this:
 ![Amplification effect](~@images/mapping/bna_amplify.png)
 
-
-#### Trimming the Outro
+### Trimming the Outro
 In Beat Saber the map will continue for as long as the audio file lasts. E.g. this means that having silence for five seconds after the song has ended the map will still play for five seconds before terminating and bringing the player to the score view. This is why it’s important to mind the time from the last note to when the audio track ends.
 
 Go to the end of your song and play the last part and outro. From the point where you intend to have the last note(s) count to 3 or 4 seconds and pause the playback. Where your playback cursor is now located is where you should generally cut off your song. (Naturally all songs will differ, so do what makes most sense for your song.)
@@ -322,10 +299,24 @@ Go to the end of your song and play the last part and outro. From the point wher
 To trim the ending at this point do the following:
 1. From the paused playback position drag a selection from here to the end of the track (yellow vertical line) and press the `Delete` key to remove this part.
 2. Make a new selection from the end of the song track (yellow vertical line) and backwards about 2 to 3 seconds.
-3. Go to `Effects menu -> Studio Fade Out`
+3. Go to `Effects menu -> Studio Fade Out`.
 4. Done.
 
 The song will now fade out just before it gets to the end of the map and the player will be presented with the scoring results much faster.
+
+### Trimming the Intro
+This step can be useful if you need to make a more graceful fade-in for your song, if needed.
+
+If your track has arrows pointing to the left at the start it means you’ve time shifted the audio forward in time outside the timeline. If you’ve done this to shorten the intro, although not necessary, it is beneficial to trim the sound clip and add a fade in. To trim and add a fade in to the song (optional) do the following:
+1. Drag a selection from 0.0 seconds to the end of the audio track (yellow vertical lines).
+2. Click Trim audio outside selection (![Trim audio to selection](~@images/mapping/trim.png)). The arrows should now disappear. 
+3. (Optional) Make a selection from track start (vertical yellow line) to about 0.5-1 seconds (depending on intro).
+4. (Optional) Go to `Effect menu -> Fade In`.
+5. Done.
+
+Before (left) and after trim and fade-in applied (right):
+
+![Trimming the song intro](~@images/mapping/trim_fade.png)
 
 ## Exporting
 We now have our finished audio that you will use and hear in the editor and the game. It is recommended to make another WAVE file backup just in case you need to export to OGG again with a different quality setting. (`File menu -> Export as WAV`).

--- a/wiki/mapping/basic-audio.md
+++ b/wiki/mapping/basic-audio.md
@@ -25,7 +25,7 @@ This page provides both new and experienced mappers with general recommendations
 
 **Any time before upload:**  
 4. [Check your song volume](./basic-audio.html#check-song-volume) and make it [louder](./basic-audio.html#making-your-song-louder) or [softer](./basic-audio.html#making-your-song-softer) as needed  
-5. Check the length of your song outro and [trim it](./basic-audio.html#trimming-the-audio) if needed
+5. Check the length of your song outro and [trim it](./basic-audio.html#trimming-the-outro) if needed
 
 ## Song Selection for New Mappers
 Below are recommendations, **not** requirements, and will help to ease you into mapping. If you want to map 17 minutes of "In A Gadda Da Vida" for your first map then have at it but know that you’ll face a **lot** of additional challenges.


### PR DESCRIPTION
Edited flow of page. The syncing steps for AV and bpm are in one section and less important steps are under an optional header.
Can move Optional Audio Editing to the Advanced Audio page if it's too much information for Basic Audio.

