### PR TITLE
Mapping Glossary copy editing for consistency and standardization

### DIFF
--- a/wiki/mapping/glossary.md
+++ b/wiki/mapping/glossary.md
@@ -84,6 +84,7 @@ let us know in #mapping-discussion!
 | **Fast Walls** | Walls with a negative duration value greater than the map's [Half Jump Duration](#h) that appear to move past the player at a slower speed than [Hyper Walls](#h). |
 | **First Person Flying Control** | A launch option available to SteamVR and Oculus users to launch Beat Saber and have limited keyboard and mouse control over the game in a first person view. Very helpful for getting an accurate preview of lighting or walls or accessing the official editor. Abbreviated FPFC |
 | **Fixed BPM** | A song with a consistent BPM from start to finish with no variation. Also known as [Single BPM](#s). See also [Variable BPM](#uv) |
+| **Flick** | A pattern of two or more notes of the same color, typically at 1/4 precision. <details><summary>**Example Image**</summary>![Picture of flick](~@images/mapping/flick-alt.png)</details>|
 | **Flow** | The concept of placing block patterns so that the next swing a player makes feels natural and allows the body to move in proper ways. |
 | **Forehand** | A swing where the majority of the work is done by the palm side of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. Related: [Backhand](#b) |
 | **FPFC** | Acronym for First Person Flying Control |

--- a/wiki/mapping/glossary.md
+++ b/wiki/mapping/glossary.md
@@ -18,9 +18,9 @@ let us know in #mapping-discussion!
 | - | :- |
 | **3-Wide Wall** | A [Wall](#wxyz) that spans three [Lanes](#l), requiring the player to move out of the center of the [Track](#t) to avoid. This term is interchangeably used with any wall requiring the player to move out of the center of the track. This is considered never okay to use. |
 | **360 Mode** | A map characteristic that allows the [Track](#t) to rotate in 15 degree increments in a full circle. As of January 2021, these maps can only be made in [ChroMapper](#c) and in the official [Editor](#e). |
-| **4-Wide Wall** | A [Wall](#wxyz) that spans all four [Lanes](#l) and three [Rows](#r) of the standard [Track](#t), usually causing the player to fail the level unless the wall is a thin. This is considered never okay to use. |
+| **4-Wide Wall** | A [Wall](#wxyz) that spans all four [Lanes](#l) and three [Rows](#r) of the standard [Track](#t), usually causing the player to fail the level unless the wall is thin. This is considered never okay to use. |
 | **90 Mode** | A map characteristic that allows the [Track](#t) to rotate in 15 degree increments, up to 45 degrees in either direction from the center. As of January 2021, these maps can only be made in [ChroMapper](#c) and in the official [Editor](#e). |
-| **Arrow Block/Note** | A [Block](#b) with an arrow on it indicating the direction in which it must be hit. Referred to as either *Arrow Block* or *Arrow Note*. See also: [Block](#b), [Note](#n), [Dot Block/Note](#d). <details><summary>**Example Image**</summary>![Picture of arrow blocks](~@images/mapping/arrowblocks.jpg)</details> |
+| **Arrow Block/Note** | A [Block](#b) with an arrow on it indicating the direction in which it must be hit. Referred to as either *Arrow Block* or *Arrow Note*. See also: [Dot Block/Note](#d). <details><summary>**Example Image**</summary>![Picture of arrow blocks](~@images/mapping/arrowblocks.jpg)</details> |
 | **Arrow Vortex** | A free third party tool that can analyze a song's [BPM](#b) and calculate its [Offset](#o). The download and a guide on how to use the tool is available [here](./basic-audio.md#tool-assisted-bpm-calculation). |
 
 ## B
@@ -29,19 +29,19 @@ let us know in #mapping-discussion!
 | **Backhand** | A swing where the majority of the work is done by the back of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. See also: [Forehand](#f). |
 | **Beats Per Minute** | The number of beats that occur in one minute, defining the [Tempo](#t) of a song. Also known as [BPM](#b). |
 | **BeastSaber** | A website that categorizes the songs uploaded to [BeatSaver](#b) into different genres and attribute tags. Players can review songs and comment on them. A team of curators play through many songs each day and recommend the ones that stand out. Also known as *BSaber*. The link to BeastSaber can be found [here](https://bsaber.com/). |
-| **BeatSaver** | The repository for all custom songs in Beat Saber. Songs uploaded here feed automatically to [Beast Saber](#b). The link can be found [here](https://beatsaver.com/). |
+| **BeatSaver** | The repository for all custom songs in Beat Saber. Songs uploaded here automatically feed to [Beast Saber](#b). The link can be found [here](https://beatsaver.com/). |
 | **Block** | A cube with either an arrow or a dot on it. It is the primary element of gameplay. By default, blocks are either red or blue. Also known as [Note](#n). <details><summary>**Example Image**</summary>![Picture of block](~@images/mapping/arrow-block.png)</details> |
 | **BPM** | Abbreviation of [Beats Per Minute](#b). |
 | **Bomb** | A [Block](#b) that looks like a spiky circle that damages the player if their saber touches it. It is safe for a bomb to pass through the player’s body. Also known as [Mine](#m). <details><summary>**Example Image**</summary>![Picture of bomb](~@images/mapping/bomb.png)</details> |
-| **Bomb Reset** | [Bombs](#b) placed to forcibly [Reset](#r) the player’s arms. See also: [Reset](#r). <details><summary>**Example Image**</summary>![Picture of bomb reset](~@images/mapping/bombreset.jpg)</details> |
+| **Bomb Reset** | [Bombs](#b) placed to forcibly [Reset](#r) the player’s arms. <details><summary>**Example Image**</summary>![Picture of bomb reset](~@images/mapping/bombreset.jpg)</details> |
 | **Bomb Spiral/Helix** | [Bombs](#b) placed in a spiral or helical [Pattern](#p), intended to force the player to move their arms in a large circle. Referred to as either *Bomb Spiral* or *Bomb Helix*. <details><summary>**Example Image**</summary>![Picture of bomb spiral](~@images/mapping/bombspiral.jpg)</details> |
 
 ## C
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Chroma** | A mod that makes custom [Lighting](#l) [Events](#e) available to mappers, most notably allowing for full RGB color mapping. Chroma lighting can be viewed by either the core Chroma mod or the smaller ChromaLite mod. |
-| **ChroMapper** | A map [Editor] created by Caeden117, specialized in modded map creation. The editor is currently still in development and in closed beta. More info can be found [here](https://github.com/Caeden117/ChroMapper). |
-| **Column** | Horizontal divisions across the [Track](#t) in which [Blocks](#b) travel. The default track has four columns. Also known as [Lane](#l). See also: [Row](#r), [Layer](#l). |
+| **Chroma** | A mod that makes custom [Lighting](#l) and lighting [Events](#e) available to mappers, most notably allowing for full [RGB](#r) color mapping. Chroma lighting can be viewed by using either the core Chroma mod, or the smaller ChromaLite mod. |
+| **ChroMapper** | A map [Editor](#e) created by Caeden117, specialized in modded map creation. The editor is currently still in development and in closed beta. More info can be found [here](https://github.com/Caeden117/ChroMapper). |
+| **Column** | Horizontal divisions across the [Track](#t) in which [Blocks](#b) travel. The default track has four columns. Also known as [Lane](#l). See also: [Layer](#l), [Row](#r). |
 | **Controller Clash/Smash** | Any [Pattern](#p) that directs the player's hands inward at each other on the same beat, often leading to the player smashing their hands together. Higher skilled players can sometimes avoid these, but they are still highly discouraged at all levels of mapping. Referred to as either *Controller Clash* or *Controller Smash*. Also known as [Handclap](#h). <details><summary>**Example Image**</summary>![Picture of controller clash](~@images/mapping/controller-smash-alt.png)</details> |
 | **Corner Crouch** | A [Wall](#wxyz) [Pattern](#p) that combines a [Dodge Wall](#d) and a [Crouch Wall](#c), leaving the player a small gap to squeeze into. <details><summary>**Example Image**</summary>![Picture of corner crouch](~@images/mapping/corner-crouch-alt.png)</details> |
 | **Cover Image** | The square image associated with the song loaded into the song browser. Must be a minimum of 256x256 pixels, but not recommended to be more than 512x512 pixels. |
@@ -55,21 +55,21 @@ let us know in #mapping-discussion!
 ## D
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **.dat File** | The text file containing most content for a certain difficulty or song info in the new 2.0 song format. It contains JSON format with a different structure compared to the 1.0 song format, and a different file extension. This file format is used for both song info and for map content. See also: [Info File](#i), [Difficulty File](#d). |
+| **.dat File** | The text file containing most content for a certain difficulty or song info in the new 2.0 song format. It contains JSON format with a different structure compared to the 1.0 song format, and a different file extension. This file format is used for both song info and for map content. See also: [Difficulty File](#d), [Info File](#i). |
 | **Difficulty File** | The [.dat File](#d) containing most content for that difficulty. In the old, obsolete song format, this was a [.json File](#j). |
-| **Dodge Wall** | A vertical [Wall](#wxyz) that forces the player to move out of the way to avoid taking damage. See also: [Groove Wall](#g), [Crouch Wall](#c). <details><summary>**Example Image**</summary>![Picture of dodge wall](~@images/mapping/dodgewall.jpg)</details> |
-| **Dot Block/Note** | A [Block](#b) that can be hit from any direction. Often used as top [Row](#r) notes in lower difficulty maps or in [Sliders](#s). Referred to as either *Dot Block* or *Dot Note*. <details><summary>**Example Image**</summary>![Picture of dot note](~@images/mapping/bndot.png)</details> |
-| **Dot Spam** | A [Pattern](#p) that overuses [Dot Blocks](#d) in a single or two adjacent [Rows](#r), typically due to mapper inexperience. See also: [Dot Block/Note](#d). <details><summary>**Example Image**</summary>![Picture of dot spam](~@images/mapping/dotspam.png)</details> |
+| **Dodge Wall** | A vertical [Wall](#wxyz) that forces the player to move out of the way to avoid taking damage. See also: [Crouch Wall](#c), [Groove Wall](#g). <details><summary>**Example Image**</summary>![Picture of dodge wall](~@images/mapping/dodgewall.jpg)</details> |
+| **Dot Block/Note** | A [Block](#b) that can be hit from any direction. Often used as top [Row](#r) blocks in lower difficulty maps or in [Sliders](#s). Referred to as either *Dot Block* or *Dot Note*. <details><summary>**Example Image**</summary>![Picture of dot note](~@images/mapping/bndot.png)</details> |
+| **Dot Spam** | A [Pattern](#p) that overuses [Dot Blocks](#d) in a single or two adjacent [Rows](#r), typically due to mapper inexperience. <details><summary>**Example Image**</summary>![Picture of dot spam](~@images/mapping/dotspam.png)</details> |
 | **DD** | Abbreviation of [Double Directional](#d). |
-| **Double Directional** | A [Pattern](#p) where two sequential same colored [Blocks](#b) have the same or close orientation, typically considered for blocks within 45 degree angles of each other. The playability of this pattern depends on the amount of time given to players to [Reset](#r). This pattern is discouraged within 1.5 beats (or longer in higher [BPM](#b) songs). Abbreviated as [DD](#d). Also known as [Drumsticking](#d), though this term is outdated. <details><summary>**Example Image**</summary>![Picture of double directionals](~@images/mapping/double-directionals.jpg)</details> |
+| **Double Directional** | A [Pattern](#p) where two sequential same-colored [Blocks](#b) have the same or close orientation, typically considered for blocks within 45 degree angles of each other. The playability of this pattern depends on the amount of time given to players to [Reset](#r). This pattern is discouraged within 1.5 beats (or longer in higher [BPM](#b) songs). Abbreviated as [DD](#d). Also known as [Drumsticking](#d), though this term is outdated. <details><summary>**Example Image**</summary>![Picture of double directionals](~@images/mapping/double-directionals.jpg)</details> |
 | **Double** | A [Pattern](#p) of two different colored [Notes](#n) on the same timing and hit simultaneously. <details><summary>**Example Image**</summary>![Picture of doubles](~@images/mapping/doubles.jpg)</details> |
-| **Drumsticking** | A [Pattern](#p) where two sequential same colored [Blocks](#b) have the same or close orientation. This term is outdated. Also known as [Double Directional](#d). |
+| **Drumsticking** | A [Pattern](#p) where two sequential same-colored [Blocks](#b) have the same or close orientation. This term is outdated. Also known as [Double Directional](#d). |
 | **Drifting BPM** | An unintentionally shifting song [BPM](#b) as a result of a live performance without a metronome. Also known as [Variable BPM](#uv) and [Multiple BPM](#m). See also: [Fixed BPM](#f). |
 
 ## E
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Editor** | A generic name for any of the map editors available. See also: [ChroMapper](#c), [Mediocre Mapper](#m), [Mediocre Map Assistant 2](#m). |
+| **Editor** | A generic name for any of the map editors available. See also: [ChroMapper](#c), [Mediocre Map Assistant 2](#m), [Mediocre Mapper](#m). |
 | **.egg File** | A version of an [.ogg File](#o) used by [BeatSaver](#b). Mappers do not need to worry about this. |
 | **Environment** | The in-game play area and associated [Platform](#p), [Track](#t), and [Lighting](#l). Also known as [Platform](#p). |
 | **Error Checker** | A feature in [Mediocre Map Assistant 2](#m) that allows mappers to check for the presence of [Double Directionals](#d), [Vision Blocks](#uv), and multiple [Notes](#n) placed on the exact same timing. |
@@ -87,7 +87,7 @@ let us know in #mapping-discussion!
 | **Fast Wall** | A [Wall](#wxyz) with a negative duration value greater than the map's [Half Jump Duration](#h) that appears to move past the player at a faster speed than normal walls, but at a slower speed than a [Hyper Wall](#h). |
 | **First Person Flying Control** | A launch option available to SteamVR and Oculus users to launch Beat Saber with limited keyboard and mouse control over the game in a first person view. Very helpful for getting an accurate preview of [Lighting](#l) or [Walls](#wxyz), or accessing the official [Editor](#e). Abbreviated as [FPFC](#f). |
 | **Fixed BPM** | A song with a consistent [BPM](#b) from start to finish with no variation. Also known as [Single BPM](#s). See also: [Variable BPM](#uv). |
-| **Flick** | A [Pattern](#p) of two or more [Notes](#n) of the same color, typically at 1/4 precision. <details><summary>**Example Image**</summary>![Picture of flick](~@images/mapping/flick-alt.png)</details> |
+| **Flick** | A [Pattern](#p) of two or more [Notes](#n) of the same color, typically at 1/4 [Precision](#p). <details><summary>**Example Image**</summary>![Picture of flick](~@images/mapping/flick-alt.png)</details> |
 | **Flow** | The concept of placing [Blocks](#b) and [Patterns](#p) so that the next swing a player makes feels natural and allows the body to move in proper ways. |
 | **Forehand** | A swing where the majority of the work is done by the palm side of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. See also: [Backhand](#b). |
 | **FPFC** | Abbreviation of [First Person Flying Control](#f). |
@@ -96,12 +96,12 @@ let us know in #mapping-discussion!
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
 | **Gallop** | A rapid [Pattern](#p) of two single [Notes](#n) followed by a [Double](#d). Significantly difficult to play, and discouraged at high [Tempos](#t) and high [Precision](#p). This pattern can also add unintended emphasis. <details><summary>**Example Image**</summary>![Picture of gallop](~@images/mapping/gallop.png)</details> |
-| **Groove Wall** | A [Wall](#wxyz) that is paired with a [Note](#n) that creates a motion involving both arms and body. See also: [Dodge Wall](#d), [Crouch Wall](#c). <details><summary>**Example Image**</summary>![Picture of groove wall](~@images/mapping/groovewall.jpg)</details> |
+| **Groove Wall** | A [Wall](#wxyz) that is paired with a [Note](#n) that creates a motion involving both arms and body. See also: [Crouch Wall](#c), [Dodge Wall](#d). <details><summary>**Example Image**</summary>![Picture of groove wall](~@images/mapping/groovewall.jpg)</details> |
 
 ## H
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Half Jump Duration** | The distance down the [Track](#t) where the [Blocks](#b) and [Obstacles](#o) spawn. Measured in beats, therefore varies in "spatial" distance by [BPM](#b). Also known as [Spawn Distance](#s). See also: [Spawn Point](#s), [NJS](#n), [BPM](#b), [Spawn Offset](#s). |
+| **Half Jump Duration** | The distance down the [Track](#t) where the [Blocks](#b) and [Obstacles](#o) spawn. Measured in beats, therefore varies in "spatial" distance by [BPM](#b). Also known as [Spawn Distance](#s). See also: [NJS](#n), [Spawn Offset](#s), [Spawn Point](#s). |
 | **Hammer Hit** | A [Pattern](#p) composed of an [Arrow Block](#a) pointing at a [Bomb](#b), forcing the player to swing their saber at the arrow block but stopping short to avoid the bomb,  making it impossible to get full points. This pattern is highly discouraged. <details><summary>**Example Image**</summary>![Picture of hammer hit](~@images/mapping/hammer-hit-alt.png)</details> |
 | **Handclap** | Any [Pattern](#p) that directs the player's hands inward at each other on the same beat, often leading to the player smashing their hands together. Higher skilled players can sometimes avoid these, but they are still highly discouraged at all levels of mapping. Also known as [Controller Clash/Smash](#c). <details><summary>**Example Image**</summary>![Picture of handclap](~@images/mapping/controller-smash-alt.png)</details> |
 | **Hitbox** | The region where the saber collides with an object. [Note](#n) hitboxes are larger than they visually appear, [Bomb](#b) hitboxes are smaller than they visually appear, and [Wall](#wxyz) hitboxes are exactly the size that they visually appear. |
@@ -114,14 +114,14 @@ let us know in #mapping-discussion!
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
 | **Info File** | The primary map file that includes information and metadata for all difficulties of a map. In 2.0 song format, this file is a [.dat File](#d). In 1.0 song format, this is a [.json File](#j). See also: [Difficulty File](#d). |
-| **Inline** | A [Pattern](#p) that remains in one [Column](#c) and [Row](#r) for two or more [Blocks](#b) in a row. This typically refers to two alternating colors, but not always. <details><summary>**Example Image**</summary>![Picture of inline](~@images/mapping/inline.png)</details> |
+| **Inline** | A [Pattern](#p) that remains in one [Column](#c) and [Row](#r) for two or more [Blocks](#b) in sequence. This typically refers to two alternating colors, but not always. <details><summary>**Example Image**</summary>![Picture of inline](~@images/mapping/inline.png)</details> |
 | **Inner Ring** | A small ring around the [Track](#t) found in some in-game [Environments](#e). |
 | **Invert** | [Blocks](#b) pointing inwards from the outside requiring a larger pre-swing to hit. <details><summary>**Example Image**</summary>![Picture of invert](~@images/mapping/invert.png)</details> |
 
 ## JK
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **.json File** | The text file containing most content for a certain difficulty or song info in the old 1.0 song format. It contains JSON format with a different structure to [.dat Files](#d), and a different file extension. This file format is used for both song info and for map content. See also: [Info File](#i), [Difficulty File](#d). |
+| **.json File** | The text file containing most content for a certain difficulty or song info in the old 1.0 song format. It contains JSON format with a different structure to [.dat Files](#d), and a different file extension. This file format is used for both song info and for map content. See also: [Difficulty File](#d), [Info File](#i). |
 | **JSON Wall** | A style of mapping requiring the mod [Mapping Extensions](#m), in which the mapper can be extremely creative with non-standard [Wall](#wxyz) types and sizes. Not recommended for novice mappers. |
 | **Jump** | A [Pattern](#p) that moves across multiple [Columns](#l) horizontally or [Rows](#r) vertically in rapid succession. This pattern is not recommended below 1/2 [Precision](#p), especially at high [Tempos](#t). The faster the jumps are, the more difficult they are to execute. See also: [Jump Stream](#jk). <details><summary>**Example Image**</summary>![Picture of jump](~@images/mapping/jump.jpg)</details> |
 | **Jump Stream** | A [Pattern](#p) that includes [Jumps](#jk) within a [Stream](#s). <details><summary>**Example Image**</summary>![Picture of jump stream](~@images/mapping/jumpstream.jpg)</details> |
@@ -129,8 +129,8 @@ let us know in #mapping-discussion!
 ## L
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Lane** | Horizontal divisions across the [Track](#t) in which [Blocks](#b) travel. The default track has four lanes. Also known as [Column](#c). See also: [Row](#r), [Layer](#l). |
-| **Layer** | Vertical divisions above the [Track](#t) in which [Blocks](#b) travel. The default track has three layers, commonly referred to as bottom, middle, and top. Also known as [Row](#r). See also: [Lane](#l), [Column](#c). |
+| **Lane** | Horizontal divisions across the [Track](#t) in which [Blocks](#b) travel. The default track has four lanes. Also known as [Column](#c). See also: [Layer](#l), [Row](#r). |
+| **Layer** | Vertical divisions above the [Track](#t) in which [Blocks](#b) travel. The default track has three layers, commonly referred to as bottom, middle, and top. Also known as [Row](#r). See also: [Column](#c), [Lane](#l). |
 | **Lawless Mode** | A map characteristic where mappers can do crazy stuff that they would normally get downvoted into oblivion for in a standard map. This mode is not part of the base game and requires the [SongCore](#s) mod. |
 | **Lefty Stream** | A straight [Stream](#s) where each pair of successive [Notes](#n) going in the same direction starts with the left hand. See also: [Righty Stream](#r). <details><summary>**Example Image**</summary>![Picture of lefty stream](~@images/mapping/lefty-stream.jpg)</details> |
 | **Lighting** | A collective term for all of the lighting events and options available to mappers. A map is not considered complete without some form of lighting. See also: [Event](#e). |
@@ -142,12 +142,12 @@ let us know in #mapping-discussion!
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
 | **Map Blindness** | A condition that may occur when a mapper has spent so much time on a map. You know the patterns, you know your intentions, and you've self-tested it so many times. Eventually, muscle memory and your subconscious kick in, and you can play the map with your eyes closed, regardless of flaws. See also: [Playtest](#t). |
-| **Mapping Extensions** | A mod developed by Kyle1314 that allows mappers to access a number of unique utilities for advanced mapping. See also: [Precision Placement](#p), [Precision Rotation](#p), [JSON Walls](#jk). |
+| **Mapping Extensions** | A mod developed by Kyle1314 that allows mappers to access a number of unique utilities for advanced mapping. See also: [JSON Walls](#jk), [Precision Placement](#p), [Precision Rotation](#p). |
 | **Mediocre Map Assistant 2** | A new fork of [Mediocre Mapper](#m) by Assistant. This is the primary map [Editor](#e) used by the mapping community. |
-| **Mediocre Mapper** | An outdated editor, developed by squeaksies as a fork of the original EditSaber [Editor](#e) by Ikiewa. No longer in public development or supported by its author, it has been forked to created [Mediocre Map Assistant 2](#m). |
+| **Mediocre Mapper** | An outdated [Editor](#e), developed by squeaksies as a fork of the original EditSaber editor by Ikiewa. No longer in public development or supported by its author, it has been forked to created [Mediocre Map Assistant 2](#m). |
 | **Mine** | A [Block](#b) that looks like a spiky circle that damages the player if their saber touches it. It is safe for a bomb to pass through the player’s body. Also known as [Bomb](#b). |
 | **Mismap** | A mistake, incorrect, or faulty choice in a map. |
-| **Modding** | Modding is a term borrowed from [osu!](#o). It is the process of reviewing and providing feedback for a map via [editor](#e) and in-game analysis for rankability and/or general improvements. This term is unrelated to game mods that alter the UI or gameplay of Beat Saber. See this [guide](https://bit.ly/ScoreSaberModding) to get started with modding. See also: [Playtest](#p). |
+| **Modding** | Modding is a term borrowed from [osu!](#o). It is the process of reviewing and providing feedback for a map via [editor](#e) and in-game analysis for rankability and/or general improvements. This term is unrelated to game mods that alter the UI or gameplay of Beat Saber. A guide on how to get started with modding can be found [here](https://bit.ly/ScoreSaberModding). See also: [Playtest](#p). |
 | **Multiple BPM** | A song with one or more [BPM](#b) changes as intended by the song’s composer. Also known as [Variable BPM](#uv) and [Drifting BPM](#d). See also: [Fixed BPM](#f). |
 
 ## N
@@ -164,7 +164,7 @@ let us know in #mapping-discussion!
 ## O
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Obstacle** | A generic term for both all types of [Walls](#wxyz) and [Bombs](#b). See also: [Wall](#wxyz), [Fake Wall](#f), [Bomb](#b). |
+| **Obstacle** | A generic term for all types of [Walls](#wxyz) and [Bombs](#b). See also: [Fake Wall](#f). |
 | **Offset** | A value in milliseconds (ms) used in the map [Editor](#e) to perfectly align the [Track](#t) beat markers with the beat of the music. Song files set up correctly with the [BPM](#b) aligned in an audio editor do not usually need an offset value. |
 | **.ogg File** | The [OGG Vorbis](https://en.wikipedia.org/wiki/Vorbis) audio file format. |
 | **OHJ** | Abbreviation of [One Handed Jump](#o). |
@@ -192,7 +192,7 @@ let us know in #mapping-discussion!
 ## Q
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Quad** | A horizontal [Pattern](#p) of four horizontal [Blocks](#b) of the same color across the [Track](#t). This pattern is very difficult to score well on the entire hit, and is highly discouraged. This pattern can easily be replaced with a [Slider](#s). <details><summary>**Example Image**</summary>![Picture of a quad](~@images/mapping/quad.jpg)</details> |
+| **Quad** | A horizontal [Pattern](#p) of four horizontal [Blocks](#b) of the same color across the [Track](#t). This pattern is very difficult to score well on the entire hit, and is highly discouraged. This pattern can be easily replaced with a [Slider](#s). <details><summary>**Example Image**</summary>![Picture of a quad](~@images/mapping/quad.jpg)</details> |
 
 ## R
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
@@ -203,7 +203,7 @@ let us know in #mapping-discussion!
 | **RGB** | A style of [Lighting](#l) that requires the [Chroma](#c) mod and allows lighting events to be of any color and to use more than two colors. |
 | **Right Triangle** | A variation of a [Triangle](#t) where there is a 90 degree hit in the sequence causing major comfort issues at lower [Precisions](#p). <details><summary>**Example Image**</summary>![Picture of right triangle](~@images/mapping/right-triangle.jpg)</details> |
 | **Righty Stream** | A straight [Stream](#s) where each pair of successive [Notes](#n) going in the same direction starts with the right hand. See also: [Lefty Stream](#l). <details><summary>**Example Image**</summary>![Picture of righty stream](~@images/mapping/righty-stream.jpg)</details> |
-| **Row** | Vertical divisions above the [Track](#t) in which [Blocks](#b) travel. The default track has three layers, commonly referred to as bottom, middle, and top. Also known as [Layer](#l). See also: [Lane](#l), [Column](#c). |
+| **Row** | Vertical divisions above the [Track](#t) in which [Blocks](#b) travel. The default track has three layers, commonly referred to as bottom, middle, and top. Also known as [Layer](#l). See also: [Column](#c), [Lane](#l). |
 
 ## S
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
@@ -214,16 +214,16 @@ let us know in #mapping-discussion!
 | **Setup** | The process of maneuvering the player's arms into position for a [Pattern](#p) via appropriate placement of the preceding [Blocks](#b). |
 | **Single** | A single [Block](#b) hit with one saber. Typically makes up the majority of [Patterns](#p) in a map. See also: [Double](#d). |
 | **Single BPM** | A song with a consistent [BPM](#b) from start to finish with no variation. Also known as [Fixed BPM](#f). See also: [Variable BPM](#uv). |
-| **Sliders** | A series of same-colored [Dot Notes](#d) or [Arrow Blocks](#a) spaced close enough together for the player to sweep the saber through in one motion. Placed at a [Precision](#p) of 1/12 or faster. <details><summary>**Example Image**</summary>![Picture of sliders](~@images/mapping/sliders.png)</details> |
-| **SongCore** | A mod for handling custom song additions in Beat Saber. |
-| **Spawn Distance** | The distance down the [Track](#t) where the [Blocks](#b) and [Obstacles](#o) spawn. Measured in beats, therefore varies in "spatial" distance by [BPM](#b). Also known as [Half Jump Duration](#h). See also: [Spawn Point](#s), [NJS](#n), [BPM](#b), [Spawn Offset](#s). |
+| **Sliders** | A series of same-colored [Dot Blocks](#d) or [Arrow Blocks](#a) spaced close enough together for the player to sweep the saber through in one motion. Placed at a [Precision](#p) of 1/12 or faster. <details><summary>**Example Image**</summary>![Picture of sliders](~@images/mapping/sliders.png)</details> |
+| **SongCore** | A mod developed by Kyle1314 for handling custom song additions in Beat Saber. |
+| **Spawn Distance** | The distance down the [Track](#t) where the [Blocks](#b) and [Obstacles](#o) spawn. Measured in beats, therefore varies in "spatial" distance by [BPM](#b). Also known as [Half Jump Duration](#h). See also: [NJS](#n), [Spawn Offset](#s), [Spawn Point](#s). |
 | **Spawn Distance Modifier** | A variable denoted as `_noteJumpStartBeatOffset` in the map's [Info File](#i) that modifies the [Spawn Distance](#d). Can be a floating value, typically between -1.0 and 1.0. Also known as [Spawn Offset](#s).
 | **Spawn Offset** | A variable denoted as `_noteJumpStartBeatOffset` in the map's [Info File](#i) that modifies the [Spawn Distance](#d). Can be a floating value, typically between -1.0 and 1.0. Also known as [Spawn Distance Modifier](#s). |
-| **Spawn Point** | The location on the [Track] where [Blocks] and [Obstacles] first appear, accompanied by a flash of light. See also: [Spawn Distance](#s). |
-| **Spiral** | A [Slider](#s) whose path traces a rotation long enough to return to its original direction or further. See also: [Bomb Spiral](#b). <details><summary>**Example Image**</summary>![Picture of spiral](~@images/mapping/spiral.jpg)</details> |
-| **Stack** | Two same-colored, same-direction [Blocks] placed in a line on the same beat. Results in the player swinging a larger, faster hit. See also: [Tower](#t). <details><summary>**Example Image**</summary>![Picture of stack](~@images/mapping/stacks.jpg)</details> |
+| **Spawn Point** | The location on the [Track](#t) where [Blocks](#b) and [Obstacles](#o) first appear, accompanied by a flash of light. See also: [Spawn Distance](#s). |
+| **Spiral** | A [Slider](#s) whose path traces a rotation long enough to return to its original direction or further. See also: [Bomb Spiral/Helix](#b). <details><summary>**Example Image**</summary>![Picture of spiral](~@images/mapping/spiral.jpg)</details> |
+| **Stack** | Two same-colored, same-direction [Blocks](#b) placed in a line on the same beat. Results in the player swinging a larger, faster hit. See also: [Tower](#t). <details><summary>**Example Image**</summary>![Picture of stack](~@images/mapping/stacks.jpg)</details> |
 | **Stagger** | A [Slider](#s) placed with the spacing between [Blocks](#b) too large for the player to hit in one motion. This is considered a [Mismap](#m). Occurs when sliders are placed slower than 1/8 [Precision](#p). <details><summary>**Example Image**</summary>![Picture of stagger](~@images/mapping/stagger.jpg)</details> |
-| **Staircase** | A [Pattern] where a [Block](#s)'s direction points towards the following block. This does not include blocks on the same beat. Can be a potential [Hitbox](#h) issue where a block is placed in the post-swing of a previous block. <details><summary>**Example Image**</summary>![Picture of staircase](~@images/mapping/staircase.jpg)</details> |
+| **Staircase** | A [Pattern](#p) where a [Block](#s)'s direction points towards the following block. This does not include blocks on the same beat. Can be a potential [Hitbox](#h) issue where a block is placed in the post-swing of a previous block. <details><summary>**Example Image**</summary>![Picture of staircase](~@images/mapping/staircase.jpg)</details> |
 | **Stream** | A steady, sustained [Pattern](#p) of [Notes](#n), typically at 1/4 [Precision](#p). <details><summary>**Example Image**</summary>![Picture of stream](~@images/mapping/stream.png)</details> |
 | **Strobe** | 1) *noun*. A rapidly flashing on/off light. <br> 2) *verb*. To cause a light to flash on/off or flicker when [Lighting](#l) a map. |
 | **Swings Per Second** | A variation on [Notes Per Second](#n) that is not inflated by use of [Sliders](#s). This metric can give a better representation of a map's difficulty. |
@@ -231,11 +231,11 @@ let us know in #mapping-discussion!
 ## T
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Tangle** | A [Pattern](#p) that results in arm paths preventing the next motion from occurring without [Resetting](#r). This occurs commonly in incorrect [Crossovers](#c). |
+| **Tangle** | A [Pattern](#p) that results in arm paths preventing the next motion from occurring without [Resetting](#r). This occurs commonly in incorrect implementations of [Crossovers](#c). |
 | **Tempo** | A musical term for the speed of music. The tempo can change throughout the duration of a song. |
 | **Testplay** | The act of playing a [WIP](#wxyz) map to check for errors and improvements. Highly recommended for creating a quality product. Also known as [Playtest](#p). |
-| **Thin Wall** | A [Wall](#wxyz) that is only a tiny fraction of a beat long that sometimes does not cause any damage to the player. Created in [Mediocre Map Assistant 2](#m) by clicking to add a wall then immediately clicking to "drop" it, without scrolling for any time duration. See also: [Wall](#wxyz), [Fake Wall](#f). <details><summary>**Example Image**</summary>![Picture of thin wall](~@images/mapping/thinwall.png)</details> |
-| **Tower** | Three same-colored, same-direction [Blocks] placed in a line on the same beat. Results in the player swinging a larger, faster hit. See also: [Stack](#s). <details><summary>**Example Image**</summary>![Picture of tower](~@images/mapping/tower.jpg)</details>|
+| **Thin Wall** | A [Wall](#wxyz) that is only a tiny fraction of a beat long that sometimes does not cause any damage to the player. Created in [Mediocre Map Assistant 2](#m) by clicking to add a wall then immediately clicking to "drop" it, without scrolling for any time duration. See also: [Fake Wall](#f). <details><summary>**Example Image**</summary>![Picture of thin wall](~@images/mapping/thinwall.png)</details> |
+| **Tower** | Three same-colored, same-direction [Blocks](#b) placed in a line on the same beat. Results in the player swinging a larger, faster hit. See also: [Stack](#s). <details><summary>**Example Image**</summary>![Picture of tower](~@images/mapping/tower.jpg)</details>|
 | **Track** | The area in an [Editor](#e) where [Blocks](#b) are placed and the area in-game where blocks spawn and move towards the player. In most editors, there is a track for blocks and a separate track for [Lighting](#l). See also: [Lighting Track](#l). |
 | **Triangle** | Three or more [Notes](#n) forming a "triangle" [Pattern](#p) with position and orientation, causing a [Wrist Reset](#wxyz), especially if used in high [Precision](#p) (under 1/1). <details><summary>**Example Image**</summary>![Picture of triangle](~@images/mapping/triangle.png)</details> |
 
@@ -245,12 +245,12 @@ let us know in #mapping-discussion!
 | **Variable BPM** | 1) A song with an intentionally shifting [BPM](#b) as intended by its composer. <br> 2) A song with irregular, unintentionally shifting BPM as a result of fluctuations. For example, a live performance without a metronome (example provided by [ScoreSaber](#s)'s Ranking Criteria). <br> Also known as [Drifting BPM](#d) and [Multiple BPM](#m). See also: [Fixed BPM](#f). |
 | **VB** | Abbeviation of [Vision Block](#uv). |
 | **Vibro Stream** | An extremely high speed [Stream](#s) of a pace requiring small wrist motions to hit, typically at 1/8 [Precision](#p). Note that this does not apply to [Dot Notes](#d). Referred to as either *Vibro* or *Vibro Stream*. <details><summary>**Example Image**</summary>![Picture of vibro](~@images/mapping/vibro.jpg)</details> |
-| **Vision Block** | A sequence of [Notes](#n), typically using the middle [Row](#r), that block the player’s vision of the following notes. The most common form of vision blocks are [Face Notes](#f), but blocks outside of the center two squares can also block line of sight to later blocks. Abbreviated as [VB](#uv). <details><summary>**Example Image**</summary>![Picture of vision block](~@images/mapping/vb_example.png)</details> |
+| **Vision Block** | A sequence of [Notes](#n), typically using the middle [Row](#r), that block the player’s vision of the following notes. The most common form of vision blocks are [Face Notes](#f), but notes outside of the center two squares can also block line of sight to later notes. Abbreviated as [VB](#uv). <details><summary>**Example Image**</summary>![Picture of vision block](~@images/mapping/vb_example.png)</details> |
 
 ## WXYZ
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Wall** | A translucent barrier that damages the player if they put their head in it. It is safe for players to rest their sabers in walls. See also: [Obstacle](#o), [Fake Walls](#f). <details><summary>**Example Image**</summary>![Picture of wall](~@images/mapping/wall.png)</details> |
+| **Wall** | A translucent barrier that damages the player if they put their head in it. It is safe for players to rest their sabers in walls. See also: [Fake Walls](#f), [Obstacle](#o). <details><summary>**Example Image**</summary>![Picture of wall](~@images/mapping/wall.png)</details> |
 | **Window** | A 3-block or larger [Tower](#t) containing a gap allowing for vision through the tower. <details><summary>**Example Image**</summary>![Picture of window](~@images/mapping/window.jpg)</details> |
 | **Window Slider** | A 3-long [Slider](#s) with the center [Note](#n) removed to allow for better vision. |
 | **WIP** | Abbreviation of "Work-In-Progress", meaning not yet finished. WIP maps must be played in either party mode or practice mode until released to prevent stray [ScoreSaber](#s) leaderboards from being created for each revision. |

--- a/wiki/mapping/glossary.md
+++ b/wiki/mapping/glossary.md
@@ -27,14 +27,14 @@ let us know in #mapping-discussion!
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
 | **Backhand** | A swing where the majority of the work is done by the back of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. See also: [Forehand](#f). |
-| **Beats Per Minute** | The number of beats that occur in one minute, defining the [Tempo](#t) of a song. Also known as [BPM](#b). |
 | **BeastSaber** | A website that categorizes the songs uploaded to [BeatSaver](#b) into different genres and attribute tags. Players can review songs and comment on them. A team of curators play through many songs each day and recommend the ones that stand out. Also known as *BSaber*. The link to BeastSaber can be found [here](https://bsaber.com/). |
+| **Beats Per Minute** | The number of beats that occur in one minute, defining the [Tempo](#t) of a song. Also known as [BPM](#b). |
 | **BeatSaver** | The repository for all custom songs in Beat Saber. Songs uploaded here automatically feed to [Beast Saber](#b). The link can be found [here](https://beatsaver.com/). |
 | **Block** | A cube with either an arrow or a dot on it. It is the primary element of gameplay. By default, blocks are either red or blue. Also known as [Note](#n). <details><summary>**Example Image**</summary>![Picture of block](~@images/mapping/arrow-block.png)</details> |
-| **BPM** | Abbreviation of [Beats Per Minute](#b). |
 | **Bomb** | A [Block](#b) that looks like a spiky circle that damages the player if their saber touches it. It is safe for a bomb to pass through the player’s body. Also known as [Mine](#m). <details><summary>**Example Image**</summary>![Picture of bomb](~@images/mapping/bomb.png)</details> |
 | **Bomb Reset** | [Bombs](#b) placed to forcibly [Reset](#r) the player’s arms. <details><summary>**Example Image**</summary>![Picture of bomb reset](~@images/mapping/bombreset.jpg)</details> |
 | **Bomb Spiral/Helix** | [Bombs](#b) placed in a spiral or helical [Pattern](#p), intended to force the player to move their arms in a large circle. Referred to as either *Bomb Spiral* or *Bomb Helix*. <details><summary>**Example Image**</summary>![Picture of bomb spiral](~@images/mapping/bombspiral.jpg)</details> |
+| **BPM** | Abbreviation of [Beats Per Minute](#b). |
 
 ## C
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
@@ -45,10 +45,10 @@ let us know in #mapping-discussion!
 | **Controller Clash/Smash** | Any [Pattern](#p) that directs the player's hands inward at each other on the same beat, often leading to the player smashing their hands together. Higher skilled players can sometimes avoid these, but they are still highly discouraged at all levels of mapping. Referred to as either *Controller Clash* or *Controller Smash*. Also known as [Handclap](#h). <details><summary>**Example Image**</summary>![Picture of controller clash](~@images/mapping/controller-smash-alt.png)</details> |
 | **Corner Crouch** | A [Wall](#wxyz) [Pattern](#p) that combines a [Dodge Wall](#d) and a [Crouch Wall](#c), leaving the player a small gap to squeeze into. <details><summary>**Example Image**</summary>![Picture of corner crouch](~@images/mapping/corner-crouch-alt.png)</details> |
 | **Cover Image** | The square image associated with the song loaded into the song browser. Must be a minimum of 256x256 pixels, but not recommended to be more than 512x512 pixels. |
-| **Crouch Wall** | A [Wall](#wxyz) blocking the upper portion of the playspace which forces the player to crouch to avoid. <details><summary>**Example Image**</summary>![Picture of corner crouch](~@images/mapping/crouch.jpg)</details> |
 | **Croissant** | A [Stream](#s) [Pattern](#p) that has the player swing in the shape of an X. The name is due to its shape and being very comfortable, or "tasty". <details><summary>**Example Image**</summary>![Picture of croissant](~@images/mapping/croissant-pattern.png)</details> |
 | **Crossover** | A [Block](#b) placed on its opposite-handed side. For example, a blue block placed in [Lanes](#l) one or two, or a red block placed in lanes three or four, primarily when the [Pattern](#p) forces the player's arms to "cross over" to play. <details><summary>**Example Image**</summary>![Picture of crossover](~@images/mapping/crossover.png)</details> |
 | **Crossover Scissor** | A [Pattern](#p) where a red and blue [Note](#n) are on opposite-handed sides and are hit simultaneously in opposite directions. Also known as [Pickle](#p). See also: [Scissor](#s). <details><summary>**Example Image**</summary>![Picture of crossover scissor](~@images/mapping/arm-tangle-alt.png)</details> |
+| **Crouch Wall** | A [Wall](#wxyz) blocking the upper portion of the playspace which forces the player to crouch to avoid. <details><summary>**Example Image**</summary>![Picture of corner crouch](~@images/mapping/crouch.jpg)</details> |
 | **Cucumber** | When a red and blue [Note](#n) are on the same timing, and are hit simultaneously in opposite directions. Also known as [Scissor](#s). See also: [Crossover Scissor](#c). <details><summary>**Example Image**</summary>![Picture of scissor](~@images/mapping/scissor-cucumber_example.png)</details> |
 | **Cursor Precision** | The musical duration of the spacing between [Notes](#n). Typically 1/1 (one note per beat), 1/2 (one note per half beat), or 1/4 (one note per quarter beat). Also known as [Precision](#p). |
 
@@ -56,15 +56,15 @@ let us know in #mapping-discussion!
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
 | **.dat File** | The text file containing most content for a certain difficulty or song info in the new 2.0 song format. It contains JSON format with a different structure compared to the 1.0 song format, and a different file extension. This file format is used for both song info and for map content. See also: [Difficulty File](#d), [Info File](#i). |
+| **DD** | Abbreviation of [Double Directional](#d). |
 | **Difficulty File** | The [.dat File](#d) containing most content for that difficulty. In the old, obsolete song format, this was a [.json File](#j). |
 | **Dodge Wall** | A vertical [Wall](#wxyz) that forces the player to move out of the way to avoid taking damage. See also: [Crouch Wall](#c), [Groove Wall](#g). <details><summary>**Example Image**</summary>![Picture of dodge wall](~@images/mapping/dodgewall.jpg)</details> |
 | **Dot Block/Note** | A [Block](#b) that can be hit from any direction. Often used as top [Row](#r) blocks in lower difficulty maps or in [Sliders](#s). Referred to as either *Dot Block* or *Dot Note*. <details><summary>**Example Image**</summary>![Picture of dot note](~@images/mapping/bndot.png)</details> |
 | **Dot Spam** | A [Pattern](#p) that overuses [Dot Blocks](#d) in a single or two adjacent [Rows](#r), typically due to mapper inexperience. <details><summary>**Example Image**</summary>![Picture of dot spam](~@images/mapping/dotspam.png)</details> |
-| **DD** | Abbreviation of [Double Directional](#d). |
-| **Double Directional** | A [Pattern](#p) where two sequential same-colored [Blocks](#b) have the same or close orientation, typically considered for blocks within 45 degree angles of each other. The playability of this pattern depends on the amount of time given to players to [Reset](#r). This pattern is discouraged within 1.5 beats (or longer in higher [BPM](#b) songs). Abbreviated as [DD](#d). Also known as [Drumsticking](#d), though this term is outdated. <details><summary>**Example Image**</summary>![Picture of double directionals](~@images/mapping/double-directionals.jpg)</details> |
 | **Double** | A [Pattern](#p) of two different colored [Notes](#n) on the same timing and hit simultaneously. <details><summary>**Example Image**</summary>![Picture of doubles](~@images/mapping/doubles.jpg)</details> |
-| **Drumsticking** | A [Pattern](#p) where two sequential same-colored [Blocks](#b) have the same or close orientation. This term is outdated. Also known as [Double Directional](#d). |
+| **Double Directional** | A [Pattern](#p) where two sequential same-colored [Blocks](#b) have the same or close orientation, typically considered for blocks within 45 degree angles of each other. The playability of this pattern depends on the amount of time given to players to [Reset](#r). This pattern is discouraged within 1.5 beats (or longer in higher [BPM](#b) songs). Abbreviated as [DD](#d). Also known as [Drumsticking](#d), though this term is outdated. <details><summary>**Example Image**</summary>![Picture of double directionals](~@images/mapping/double-directionals.jpg)</details> |
 | **Drifting BPM** | An unintentionally shifting song [BPM](#b) as a result of a live performance without a metronome. Also known as [Variable BPM](#uv) and [Multiple BPM](#m). See also: [Fixed BPM](#f). |
+| **Drumsticking** | A [Pattern](#p) where two sequential same-colored [Blocks](#b) have the same or close orientation. This term is outdated. Also known as [Double Directional](#d). |
 
 ## E
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
@@ -130,8 +130,8 @@ let us know in #mapping-discussion!
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
 | **Lane** | Horizontal divisions across the [Track](#t) in which [Blocks](#b) travel. The default track has four lanes. Also known as [Column](#c). See also: [Layer](#l), [Row](#r). |
-| **Layer** | Vertical divisions above the [Track](#t) in which [Blocks](#b) travel. The default track has three layers, commonly referred to as bottom, middle, and top. Also known as [Row](#r). See also: [Column](#c), [Lane](#l). |
 | **Lawless Mode** | A map characteristic where mappers can do crazy stuff that they would normally get downvoted into oblivion for in a standard map. This mode is not part of the base game and requires the [SongCore](#s) mod. |
+| **Layer** | Vertical divisions above the [Track](#t) in which [Blocks](#b) travel. The default track has three layers, commonly referred to as bottom, middle, and top. Also known as [Row](#r). See also: [Column](#c), [Lane](#l). |
 | **Lefty Stream** | A straight [Stream](#s) where each pair of successive [Notes](#n) going in the same direction starts with the left hand. See also: [Righty Stream](#r). <details><summary>**Example Image**</summary>![Picture of lefty stream](~@images/mapping/lefty-stream.jpg)</details> |
 | **Lighting** | A collective term for all of the lighting events and options available to mappers. A map is not considered complete without some form of lighting. See also: [Event](#e). |
 | **Lighting Track** | The area in most map editors where [Lighting](#l) events are placed. See also: [Track](#t). |
@@ -154,12 +154,12 @@ let us know in #mapping-discussion!
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
 | **NJS** | Abbreviation of [Note Jump Speed](#n). |
-| **NPS** | Abbreviation of [Notes Per Second](#n). |
 | **No Arrows Mode** | A map characteristic using only [Dot Notes](#d). Often used by new players or for alternate play styles like "maul mode." |
 | **Noodle Extensions** | A more advanced version of [Mapping Extensions](#m) that is only available on PC. |
 | **Note** | A cube with either an arrow or a dot on it. It is the primary element of gameplay. By default, blocks are either red or blue. Also known as [Block](#b). |
 | **Note Jump Speed** | The speed that objects approach the player in-game. Labeled in Info.dat as `_noteJumpMovementSpeed`. Abbreviated as [NJS](#n). |
 | **Notes Per Second** | A measure of map density. The number of [Notes](#n) that pass the player within one second. A very rough approximate measure of difficulty. Abbreviated as [NPS](#n). |
+| **NPS** | Abbreviation of [Notes Per Second](#n). |
 
 ## O
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
@@ -181,9 +181,9 @@ let us know in #mapping-discussion!
 | **Paul** | A sequence of inline [Blocks](#b) of the same direction placed at very high [Precision](#p). This forces the player to hit the sequence with a slow continuous swing. This [Pattern](#p) is very difficult to score well on. <details><summary>**Example Image**</summary>![Picture of paul](~@images/mapping/paul.jpg)</details> |
 | **Piano Stream** | A sequence of alternating color and direction [Blocks](#b) that progresses horizontally across [Lanes](#l) on the [Track](#t). <details><summary>**Example Image**</summary>![Picture of piano stream](~@images/mapping/pianostream.png)</details> |
 | **Pickle** | A [Pattern](#p) where a red and blue [Note](#n) are on opposite-handed sides and are hit simultaneously in opposite directions. Also known as [Pickle](#p). See also: [Crossover Scissor](#s). <details><summary>**Example Image**</summary>![Picture of pickle](~@images/mapping/arm-tangle-alt.png)</details> |
-| **Playtest** | The act of playing a [WIP](#wxyz) map to check for errors and improvements. Highly recommended for creating a quality product. Also known as [Testplay](#t). |
 | **Performance Points** | The metric determining ranking on the [ScoreSaber](#s) leaderboards. Abbreviated as [PP](#p). |
 | **Platform** | The in-game play area and associated [Track](#t) and [Lighting](#l). Also known as [Environment](#e). |
+| **Playtest** | The act of playing a [WIP](#wxyz) map to check for errors and improvements. Highly recommended for creating a quality product. Also known as [Testplay](#t). |
 | **PP** | Abbreviation of [Performance Points](#p). |
 | **Precision** | The musical duration of the spacing between [Notes](#n). Typically 1/1 (one note per beat), 1/2 (one note per half beat), or 1/4 (one note per quarter beat). Also known as [Cursor Precision](#c). |
 | **Precision Placement** | A style of mapping that requires [Mapping Extensions](#m), which allows the mapper to place [Blocks](#b) outside of the standard 4x3 grid. Not recommended for novice mappers. |
@@ -208,9 +208,9 @@ let us know in #mapping-discussion!
 ## S
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **ScoreSaber** | The organization responsible for managing the ranked Beat Saber leaderboards. The Beat Saber leaderboards website can be found [here](https://scoresaber.com/). See also: [Performance Points](#p). |
 | **Scissor** | When a red and blue [Note](#n) are on the same timing, and are hit simultaneously in opposite directions. Also known as [Cucumber](#c). See also: [Crossover Scissor](#c). <details><summary>**Example Image**</summary>![Picture of scissor](~@images/mapping/scissor-cucumber_example.png)</details> |
 | **Scoop** | A [Pattern](#p) of [Blocks](#b) where the player makes a "scooping" motion to play the pattern. Typically a left or right note followed by an up note in the bottom row. Give the player an ample amount of time to react when using scoops - a half to full beat is recommended. <details><summary>**Example Image**</summary>![Picture of scoop](~@images/mapping/scoop_example.png)</details> |
+| **ScoreSaber** | The organization responsible for managing the ranked Beat Saber leaderboards. The Beat Saber leaderboards website can be found [here](https://scoresaber.com/). See also: [Performance Points](#p). |
 | **Setup** | The process of maneuvering the player's arms into position for a [Pattern](#p) via appropriate placement of the preceding [Blocks](#b). |
 | **Single** | A single [Block](#b) hit with one saber. Typically makes up the majority of [Patterns](#p) in a map. See also: [Double](#d). |
 | **Single BPM** | A song with a consistent [BPM](#b) from start to finish with no variation. Also known as [Fixed BPM](#f). See also: [Variable BPM](#uv). |

--- a/wiki/mapping/glossary.md
+++ b/wiki/mapping/glossary.md
@@ -85,12 +85,12 @@ let us know in #mapping-discussion!
 | **Face Wall** | A [Wall](#wxyz) occupying one of the two center [Lanes](#l). Also known as [Dodge Walls](#d). <details><summary>**Example Image**</summary>![Picture of face wall](~@images/mapping/facewall.jpg)</details> |
 | **Fake Wall** | A [Wall](#wxyz) with a negative width value, making it harmless to the player. |
 | **Fast Wall** | A [Wall](#wxyz) with a negative duration value greater than the map's [Half Jump Duration](#h) that appears to move past the player at a faster speed than normal walls, but at a slower speed than a [Hyper Wall](#h). |
-| **First Person Flying Control** | A launch option available to SteamVR and Oculus users to launch Beat Saber with limited keyboard and mouse control over the game in a first person view. Very helpful for getting an accurate preview of [Lighting](#l) or [Walls](#wxyz), or accessing the official [Editor](#e). Abbreviated as [FPFC](#f). |
+| **First Person Flying Controller** | A launch option available to SteamVR and Oculus users to launch Beat Saber with limited keyboard and mouse control over the game in a first person view. Very helpful for getting an accurate preview of [Lighting](#l) or [Walls](#wxyz), or accessing the official [Editor](#e). Abbreviated as [FPFC](#f). |
 | **Fixed BPM** | A song with a consistent [BPM](#b) from start to finish with no variation. Also known as [Single BPM](#s). See also: [Variable BPM](#uv). |
 | **Flick** | A [Pattern](#p) of two or more [Notes](#n) of the same color, typically at 1/4 [Precision](#p). <details><summary>**Example Image**</summary>![Picture of flick](~@images/mapping/flick-alt.png)</details> |
 | **Flow** | The concept of placing [Blocks](#b) and [Patterns](#p) so that the next swing a player makes feels natural and allows the body to move in proper ways. |
 | **Forehand** | A swing where the majority of the work is done by the palm side of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. See also: [Backhand](#b). |
-| **FPFC** | Abbreviation of [First Person Flying Control](#f). |
+| **FPFC** | Abbreviation of [First Person Flying Controller](#f). |
 
 ## G
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
@@ -123,7 +123,7 @@ let us know in #mapping-discussion!
 | - | :- |
 | **.json File** | The text file containing most content for a certain difficulty or song info in the old 1.0 song format. It contains JSON format with a different structure to [.dat Files](#d), and a different file extension. This file format is used for both song info and for map content. See also: [Difficulty File](#d), [Info File](#i). |
 | **JSON Wall** | A style of mapping requiring the mod [Mapping Extensions](#m), in which the mapper can be extremely creative with non-standard [Wall](#wxyz) types and sizes. Not recommended for novice mappers. |
-| **Jump** | A [Pattern](#p) that moves across multiple [Columns](#l) horizontally or [Rows](#r) vertically in rapid succession. This pattern is not recommended below 1/2 [Precision](#p), especially at high [Tempos](#t). The faster the jumps are, the more difficult they are to execute. See also: [Jump Stream](#jk). <details><summary>**Example Image**</summary>![Picture of jump](~@images/mapping/jump.jpg)</details> |
+| **Jump** | A [Pattern](#p) that moves across multiple [Columns](#c) horizontally or [Rows](#r) vertically in rapid succession. See also: [Jump Stream](#jk). <details><summary>**Example Image**</summary>![Picture of jump](~@images/mapping/jump.jpg)</details> |
 | **Jump Stream** | A [Pattern](#p) that includes [Jumps](#jk) within a [Stream](#s). <details><summary>**Example Image**</summary>![Picture of jump stream](~@images/mapping/jumpstream.jpg)</details> |
 
 ## L
@@ -141,11 +141,11 @@ let us know in #mapping-discussion!
 ## M
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Map Blindness** | A condition that may occur when a mapper has spent so much time on a map. You know the patterns, you know your intentions, and you've self-tested it so many times. Eventually, muscle memory and your subconscious kick in, and you can play the map with your eyes closed, regardless of flaws. See also: [Playtest](#t). |
-| **Mapping Extensions** | A mod developed by Kyle1314 that allows mappers to access a number of unique utilities for advanced mapping. See also: [JSON Walls](#jk), [Precision Placement](#p), [Precision Rotation](#p). |
+| **Map Blindness** | A condition that may occur when a mapper has spent so much time on a map. You know the patterns, you know your intentions, and you've self-tested it so many times. Eventually, muscle memory and your subconscious kick in, and you can play the map with your eyes closed, regardless of flaws. See also: [Playtest](#p). |
+| **Mapping Extensions** | A mod developed by Kyle1413 that allows mappers to access a number of unique utilities for advanced mapping. See also: [JSON Walls](#jk), [Precision Placement](#p), [Precision Rotation](#p). |
 | **Mediocre Map Assistant 2** | A new fork of [Mediocre Mapper](#m) by Assistant. This is the primary map [Editor](#e) used by the mapping community. |
 | **Mediocre Mapper** | An outdated [Editor](#e), developed by squeaksies as a fork of the original EditSaber editor by Ikiewa. No longer in public development or supported by its author, it has been forked to created [Mediocre Map Assistant 2](#m). |
-| **Mine** | A [Block](#b) that looks like a spiky circle that damages the player if their saber touches it. It is safe for a bomb to pass through the player’s body. Also known as [Bomb](#b). |
+| **Mine** | A [Block](#b) that looks like a spiky circle that damages the player if their saber touches it. It is safe for a mine to pass through the player’s body. Also known as [Bomb](#b). |
 | **Mismap** | A mistake, incorrect, or faulty choice in a map. |
 | **Modding** | Modding is a term borrowed from [osu!](#o). It is the process of reviewing and providing feedback for a map via [editor](#e) and in-game analysis for rankability and/or general improvements. This term is unrelated to game mods that alter the UI or gameplay of Beat Saber. A guide on how to get started with modding can be found [here](https://bit.ly/ScoreSaberModding). See also: [Playtest](#p). |
 | **Multiple BPM** | A song with one or more [BPM](#b) changes as intended by the song’s composer. Also known as [Variable BPM](#uv) and [Drifting BPM](#d). See also: [Fixed BPM](#f). |
@@ -180,7 +180,7 @@ let us know in #mapping-discussion!
 | **Pattern** | A generic name for a sequence of [Blocks](#b). |
 | **Paul** | A sequence of inline [Blocks](#b) of the same direction placed at very high [Precision](#p). This forces the player to hit the sequence with a slow continuous swing. This [Pattern](#p) is very difficult to score well on. <details><summary>**Example Image**</summary>![Picture of paul](~@images/mapping/paul.jpg)</details> |
 | **Piano Stream** | A sequence of alternating color and direction [Blocks](#b) that progresses horizontally across [Lanes](#l) on the [Track](#t). <details><summary>**Example Image**</summary>![Picture of piano stream](~@images/mapping/pianostream.png)</details> |
-| **Pickle** | A [Pattern](#p) where a red and blue [Note](#n) are on opposite-handed sides and are hit simultaneously in opposite directions. Also known as [Pickle](#p). See also: [Crossover Scissor](#s). <details><summary>**Example Image**</summary>![Picture of pickle](~@images/mapping/arm-tangle-alt.png)</details> |
+| **Pickle** | A [Pattern](#p) where a red and blue [Note](#n) are on opposite-handed sides and are hit simultaneously in opposite directions. Also known as [Crossover Scissor](#c). See also: [Scissor](#s). <details><summary>**Example Image**</summary>![Picture of pickle](~@images/mapping/arm-tangle-alt.png)</details> |
 | **Performance Points** | The metric determining ranking on the [ScoreSaber](#s) leaderboards. Abbreviated as [PP](#p). |
 | **Platform** | The in-game play area and associated [Track](#t) and [Lighting](#l). Also known as [Environment](#e). |
 | **Playtest** | The act of playing a [WIP](#wxyz) map to check for errors and improvements. Highly recommended for creating a quality product. Also known as [Testplay](#t). |
@@ -215,7 +215,7 @@ let us know in #mapping-discussion!
 | **Single** | A single [Block](#b) hit with one saber. Typically makes up the majority of [Patterns](#p) in a map. See also: [Double](#d). |
 | **Single BPM** | A song with a consistent [BPM](#b) from start to finish with no variation. Also known as [Fixed BPM](#f). See also: [Variable BPM](#uv). |
 | **Sliders** | A series of same-colored [Dot Blocks](#d) or [Arrow Blocks](#a) spaced close enough together for the player to sweep the saber through in one motion. Placed at a [Precision](#p) of 1/12 or faster. <details><summary>**Example Image**</summary>![Picture of sliders](~@images/mapping/sliders.png)</details> |
-| **SongCore** | A mod developed by Kyle1314 for handling custom song additions in Beat Saber. |
+| **SongCore** | A mod developed by Kyle1413 for handling custom song additions in Beat Saber. |
 | **Spawn Distance** | The distance down the [Track](#t) where the [Blocks](#b) and [Obstacles](#o) spawn. Measured in beats, therefore varies in "spatial" distance by [BPM](#b). Also known as [Half Jump Duration](#h). See also: [NJS](#n), [Spawn Offset](#s), [Spawn Point](#s). |
 | **Spawn Distance Modifier** | A variable denoted as `_noteJumpStartBeatOffset` in the map's [Info File](#i) that modifies the [Spawn Distance](#d). Can be a floating value, typically between -1.0 and 1.0. Also known as [Spawn Offset](#s).
 | **Spawn Offset** | A variable denoted as `_noteJumpStartBeatOffset` in the map's [Info File](#i) that modifies the [Spawn Distance](#d). Can be a floating value, typically between -1.0 and 1.0. Also known as [Spawn Distance Modifier](#s). |

--- a/wiki/mapping/glossary.md
+++ b/wiki/mapping/glossary.md
@@ -16,11 +16,11 @@ let us know in #mapping-discussion!
 ## A
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **3-Wide Wall** | A [Wall](#wxyz) that spans three [Lanes](#l), requiring the player to move out of the center of the [Track](#t) to avoid. The term is interchangeably used with any wall requiring the player to move out of the center of the track. This is considered never okay to use. |
-| **360 Mode** | A map characteristic that allows the [Track](#t) to rotate in 15 degree increments in a full circle. As of January 2021, these maps can only be made in ChroMapper and in the official editor. |
-| **4-Wide Wall** | A [Wall](#wxyz) that spans all four [Lanes](#l) and three [Rows](#r) of the standard [Track](#t), usually causing the player to fail the level unless the wall is thin. This is considered never okay to use. |
-| **90 Mode** | A map characteristic that allows the track to rotate in 15 degree increments, up to 45 degrees in either direction from the center. As of January 2021, these maps can only be made in ChroMapper and in the official editor. |
-| **Arrow Block/Note** | A [Block](#b) with an arrow on it indicating the direction in which it must be hit. Also known as *Arrow Note*. See also: [Block](#b), [Note](#n), [Dot Block/Note](#d). <details><summary>**Example Image**</summary>![Picture of arrow blocks](~@images/mapping/arrowblocks.jpg)</details>|
+| **3-Wide Wall** | A [Wall](#wxyz) that spans three [Lanes](#l), requiring the player to move out of the center of the [Track](#t) to avoid. This term is interchangeably used with any wall requiring the player to move out of the center of the track. This is considered never okay to use. |
+| **360 Mode** | A map characteristic that allows the [Track](#t) to rotate in 15 degree increments in a full circle. As of January 2021, these maps can only be made in [ChroMapper](#c) and in the official [Editor](#e). |
+| **4-Wide Wall** | A [Wall](#wxyz) that spans all four [Lanes](#l) and three [Rows](#r) of the standard [Track](#t), usually causing the player to fail the level unless the wall is a thin. This is considered never okay to use. |
+| **90 Mode** | A map characteristic that allows the [Track](#t) to rotate in 15 degree increments, up to 45 degrees in either direction from the center. As of January 2021, these maps can only be made in [ChroMapper](#c) and in the official [Editor](#e). |
+| **Arrow Block/Note** | A [Block](#b) with an arrow on it indicating the direction in which it must be hit. Referred to as either *Arrow Block* or *Arrow Note*. See also: [Block](#b), [Note](#n), [Dot Block/Note](#d). <details><summary>**Example Image**</summary>![Picture of arrow blocks](~@images/mapping/arrowblocks.jpg)</details> |
 | **Arrow Vortex** | A free third party tool that can analyze a song's [BPM](#b) and calculate its [Offset](#o). The download and a guide on how to use the tool is available [here](./basic-audio.md#tool-assisted-bpm-calculation). |
 
 ## B
@@ -28,39 +28,40 @@ let us know in #mapping-discussion!
 | - | :- |
 | **Backhand** | A swing where the majority of the work is done by the back of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. See also: [Forehand](#f). |
 | **Beats Per Minute** | The number of beats that occur in one minute, defining the [Tempo](#t) of a song. Also known as [BPM](#b). |
-| **BeastSaber** | A website that categorizes the songs uploaded to [BeatSaver](#b) into different genres and attribute tags. Players can review songs and comment on them. A team of curators plays through many songs each day and recommends the ones that stand out. Also known as *BSaber*. The link can be found [here](https://bsaber.com/). |
+| **BeastSaber** | A website that categorizes the songs uploaded to [BeatSaver](#b) into different genres and attribute tags. Players can review songs and comment on them. A team of curators play through many songs each day and recommend the ones that stand out. Also known as *BSaber*. The link to BeastSaber can be found [here](https://bsaber.com/). |
 | **BeatSaver** | The repository for all custom songs in Beat Saber. Songs uploaded here feed automatically to [Beast Saber](#b). The link can be found [here](https://beatsaver.com/). |
 | **Block** | A cube with either an arrow or a dot on it. It is the primary element of gameplay. By default, blocks are either red or blue. Also known as [Note](#n). <details><summary>**Example Image**</summary>![Picture of block](~@images/mapping/arrow-block.png)</details> |
-| **BPM** | Acronym for [Beats Per Minute](#b). |
+| **BPM** | Abbreviation of [Beats Per Minute](#b). |
 | **Bomb** | A [Block](#b) that looks like a spiky circle that damages the player if their saber touches it. It is safe for a bomb to pass through the player’s body. Also known as [Mine](#m). <details><summary>**Example Image**</summary>![Picture of bomb](~@images/mapping/bomb.png)</details> |
-| **Bomb Reset** | [Bombs](#b) placed to forcibly reset the player’s arms. See also [Reset](#r). <details><summary>**Example Image**</summary>![Picture of bomb reset](~@images/mapping/bombreset.jpg)</details> |
-| **Bomb Spiral/Helix** | [Bombs](#b) placed in a spiral or helical [Pattern](#p), intended to force the player to move their arms in a large circle. <details><summary>**Example Image**</summary>![Picture of bomb spiral](~@images/mapping/bombspiral.jpg)</details> |
+| **Bomb Reset** | [Bombs](#b) placed to forcibly [Reset](#r) the player’s arms. See also: [Reset](#r). <details><summary>**Example Image**</summary>![Picture of bomb reset](~@images/mapping/bombreset.jpg)</details> |
+| **Bomb Spiral/Helix** | [Bombs](#b) placed in a spiral or helical [Pattern](#p), intended to force the player to move their arms in a large circle. Referred to as either *Bomb Spiral* or *Bomb Helix*. <details><summary>**Example Image**</summary>![Picture of bomb spiral](~@images/mapping/bombspiral.jpg)</details> |
 
 ## C
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Chroma** | A mod that makes custom lighting [Events](#e) available to mappers, most notably allowing for full RGB color mapping. Chroma lights can be viewed by either the core Chroma mod or the smaller ChromaLite mod. |
+| **Chroma** | A mod that makes custom [Lighting](#l) [Events](#e) available to mappers, most notably allowing for full RGB color mapping. Chroma lighting can be viewed by either the core Chroma mod or the smaller ChromaLite mod. |
+| **ChroMapper** | A map [Editor] created by Caeden117, specialized in modded map creation. The editor is currently still in development and in closed beta. More info can be found [here](https://github.com/Caeden117/ChroMapper). |
 | **Column** | Horizontal divisions across the [Track](#t) in which [Blocks](#b) travel. The default track has four columns. Also known as [Lane](#l). See also: [Row](#r), [Layer](#l). |
-| **Controller Clash/Smash** | Any [Pattern](#p) that directs the player's hands inward at each other on the same beat, often leading to the player smashing their hands together. Higher skilled players can sometimes avoid these, but they are still highly discouraged at all levels of mapping. Also known as [Handclap](#h). <details><summary>**Example Image**</summary>![Picture of controller clash](~@images/mapping/controller-smash-alt.png)</details> |
-| **Corner Crouch** | A wall [Pattern](#p) that combines a [Dodge Wall](#d) and a [Crouch Wall](#c), leaving the player a small gap to squeeze into. <details><summary>**Example Image**</summary>![Picture of corner crouch](~@images/mapping/corner-crouch-alt.png)</details> |
+| **Controller Clash/Smash** | Any [Pattern](#p) that directs the player's hands inward at each other on the same beat, often leading to the player smashing their hands together. Higher skilled players can sometimes avoid these, but they are still highly discouraged at all levels of mapping. Referred to as either *Controller Clash* or *Controller Smash*. Also known as [Handclap](#h). <details><summary>**Example Image**</summary>![Picture of controller clash](~@images/mapping/controller-smash-alt.png)</details> |
+| **Corner Crouch** | A [Wall](#wxyz) [Pattern](#p) that combines a [Dodge Wall](#d) and a [Crouch Wall](#c), leaving the player a small gap to squeeze into. <details><summary>**Example Image**</summary>![Picture of corner crouch](~@images/mapping/corner-crouch-alt.png)</details> |
 | **Cover Image** | The square image associated with the song loaded into the song browser. Must be a minimum of 256x256 pixels, but not recommended to be more than 512x512 pixels. |
 | **Crouch Wall** | A [Wall](#wxyz) blocking the upper portion of the playspace which forces the player to crouch to avoid. <details><summary>**Example Image**</summary>![Picture of corner crouch](~@images/mapping/crouch.jpg)</details> |
 | **Croissant** | A [Stream](#s) [Pattern](#p) that has the player swing in the shape of an X. The name is due to its shape and being very comfortable, or "tasty". <details><summary>**Example Image**</summary>![Picture of croissant](~@images/mapping/croissant-pattern.png)</details> |
-| **Crossover** | A [Block](#b) placed on its opposite-handed side. For example, a blue block placed in lanes one or two, or a red block placed in lanes three or four, primarily when the pattern forces the player's arms to "cross over" to play. <details><summary>**Example Image**</summary>![Picture of crossover](~@images/mapping/crossover.png)</details> |
-| **Crossover Scissor** | A [Pattern](#p) where a red and blue [Note](#n) are on opposite-handed sides and are hit simultaneously in opposite directions. Also known as *Pickle*. See also: [Scissor](#s). <details><summary>**Example Image**</summary>![Picture of crossover scissor](~@images/mapping/arm-tangle-alt.png)</details> |
+| **Crossover** | A [Block](#b) placed on its opposite-handed side. For example, a blue block placed in [Lanes](#l) one or two, or a red block placed in lanes three or four, primarily when the [Pattern](#p) forces the player's arms to "cross over" to play. <details><summary>**Example Image**</summary>![Picture of crossover](~@images/mapping/crossover.png)</details> |
+| **Crossover Scissor** | A [Pattern](#p) where a red and blue [Note](#n) are on opposite-handed sides and are hit simultaneously in opposite directions. Also known as [Pickle](#p). See also: [Scissor](#s). <details><summary>**Example Image**</summary>![Picture of crossover scissor](~@images/mapping/arm-tangle-alt.png)</details> |
 | **Cucumber** | When a red and blue [Note](#n) are on the same timing, and are hit simultaneously in opposite directions. Also known as [Scissor](#s). See also: [Crossover Scissor](#c). <details><summary>**Example Image**</summary>![Picture of scissor](~@images/mapping/scissor-cucumber_example.png)</details> |
 | **Cursor Precision** | The musical duration of the spacing between [Notes](#n). Typically 1/1 (one note per beat), 1/2 (one note per half beat), or 1/4 (one note per quarter beat). Also known as [Precision](#p). |
 
 ## D
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **.dat File** | The text file containing most content for a certain difficulty or song info in the new 2.0 song format. It contains JSON format with a different structure compared to 1.0, and a different file extension. This file format is used for both song info and for map content. See also: [Info File](#i), [Difficulty File](#d). |
+| **.dat File** | The text file containing most content for a certain difficulty or song info in the new 2.0 song format. It contains JSON format with a different structure compared to the 1.0 song format, and a different file extension. This file format is used for both song info and for map content. See also: [Info File](#i), [Difficulty File](#d). |
 | **Difficulty File** | The [.dat File](#d) containing most content for that difficulty. In the old, obsolete song format, this was a [.json File](#j). |
 | **Dodge Wall** | A vertical [Wall](#wxyz) that forces the player to move out of the way to avoid taking damage. See also: [Groove Wall](#g), [Crouch Wall](#c). <details><summary>**Example Image**</summary>![Picture of dodge wall](~@images/mapping/dodgewall.jpg)</details> |
-| **Dot Block/Note** | A [Block](#b) that can be hit from any direction. Often used as top notes in lower difficulty maps or in [Sliders](#s). Also known as [Dot Notes](#d). <details><summary>**Example Image**</summary>![Picture of dot note](~@images/mapping/bndot.png)</details> |
-| **Dot Spam** | A [Pattern](#p) that overuses [Dot Blocks](#d) in a single or two adjacent rows, typically due to inexperience. See also: [Dot Block/Note](#d). <details><summary>**Example Image**</summary>![Picture of dot spam](~@images/mapping/dotspam.png)</details> |
-| **DD** | Acronym for [Double Directional](#d). |
-| **Double Directional** | A [Pattern](#p) where two sequential same colored [Blocks](#b) have the same or close orientation, typically considered for blocks within 45 degree angles of each other. The playability of this pattern depends on the amount of time given to players to [Reset](#r). This pattern is discouraged within 1.5 beats (or longer in higher [BPM](#b) songs). Abbreviated as *DD*. Also known as [Drumsticking](#d) (term outdated). <details><summary>**Example Image**</summary>![Picture of double directionals](~@images/mapping/double-directionals.jpg)</details> |
+| **Dot Block/Note** | A [Block](#b) that can be hit from any direction. Often used as top [Row](#r) notes in lower difficulty maps or in [Sliders](#s). Referred to as either *Dot Block* or *Dot Note*. <details><summary>**Example Image**</summary>![Picture of dot note](~@images/mapping/bndot.png)</details> |
+| **Dot Spam** | A [Pattern](#p) that overuses [Dot Blocks](#d) in a single or two adjacent [Rows](#r), typically due to mapper inexperience. See also: [Dot Block/Note](#d). <details><summary>**Example Image**</summary>![Picture of dot spam](~@images/mapping/dotspam.png)</details> |
+| **DD** | Abbreviation of [Double Directional](#d). |
+| **Double Directional** | A [Pattern](#p) where two sequential same colored [Blocks](#b) have the same or close orientation, typically considered for blocks within 45 degree angles of each other. The playability of this pattern depends on the amount of time given to players to [Reset](#r). This pattern is discouraged within 1.5 beats (or longer in higher [BPM](#b) songs). Abbreviated as [DD](#d). Also known as [Drumsticking](#d), though this term is outdated. <details><summary>**Example Image**</summary>![Picture of double directionals](~@images/mapping/double-directionals.jpg)</details> |
 | **Double** | A [Pattern](#p) of two different colored [Notes](#n) on the same timing and hit simultaneously. <details><summary>**Example Image**</summary>![Picture of doubles](~@images/mapping/doubles.jpg)</details> |
 | **Drumsticking** | A [Pattern](#p) where two sequential same colored [Blocks](#b) have the same or close orientation. This term is outdated. Also known as [Double Directional](#d). |
 | **Drifting BPM** | An unintentionally shifting song [BPM](#b) as a result of a live performance without a metronome. Also known as [Variable BPM](#uv) and [Multiple BPM](#m). See also: [Fixed BPM](#f). |
@@ -68,28 +69,28 @@ let us know in #mapping-discussion!
 ## E
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Editor** | A generic name for any of the map editors available. |
+| **Editor** | A generic name for any of the map editors available. See also: [ChroMapper](#c), [Mediocre Mapper](#m), [Mediocre Map Assistant 2](#m). |
 | **.egg File** | A version of an [.ogg File](#o) used by [BeatSaver](#b). Mappers do not need to worry about this. |
 | **Environment** | The in-game play area and associated [Platform](#p), [Track](#t), and [Lighting](#l). Also known as [Platform](#p). |
-| **Error Checker** | A feature in [Mediocre Map Assistant 2](#m) that allows mappers to check for the presence of [Double Directionals](#d), [Vision Blocks](#uv), and stacked notes. |
+| **Error Checker** | A feature in [Mediocre Map Assistant 2](#m) that allows mappers to check for the presence of [Double Directionals](#d), [Vision Blocks](#uv), and multiple [Notes](#n) placed on the exact same timing. |
 | **Escape** | The process of maneuvering the player's arms to conclude a [Pattern](#p). Complex [Crossovers](#c) or [Obstacle](#o) patterns require carefully considered escape patterns to feel comfortable. See also: [Setup](#s). |
 | **Event** | Any non-interactable element occurrence processed by the game. |
 
 ## F
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Face Bomb** | [Bombs](#b) placed in the center two positions of the [Track](#t). Very easily hit by the hilt of the saber even when the player has their arms outstretched. <details><summary>**Example Image**</summary>![Picture of face bomb](~@images/mapping/facebomb.jpg)</details> |
+| **Face Bomb** | [Bombs](#b) placed in the center two positions of the [Track](#t). Very easily hit by the hilt of the saber even when the player has their arms outstretched. These bombs will be at the player’s face level if their height is set correctly, and are highly discouraged due to potentially causing [Vision Blocks](#uv). <details><summary>**Example Image**</summary>![Picture of face bomb](~@images/mapping/facebomb.jpg)</details> |
 | **Face Note** | [Blocks](#b) placed in the center two positions of the [Track](#t). These blocks will be at the player’s face level if their height is set correctly, and are highly discouraged due to potentially causing [Vision Blocks](#uv). <details><summary>**Example Image**</summary>![Picture of face note](~@images/mapping/facenote.jpg)</details> |
-| **Face Puncher** | A [Pattern](#p) that consists of one or two diagonal up [Blocks](#b) crossed over into the extreme opposite [Lane](#l). Many players will overswing trying to reach the blocks and end up punching their HMD.  <details><summary>**Example Image**</summary>![Picture of face puncher](~@images/mapping/facepuncher.png)</details> |
-| **Face Wall** | A [Wall](#wxyz) occupying one of the two center lanes. Also known as [Dodge Walls](#d). <details><summary>**Example Image**</summary>![Picture of face wall](~@images/mapping/facewall.jpg)</details> |
+| **Face Puncher** | [Block](#b) placement that consists of one or two diagonal up blocks crossed over into the extreme opposite [Lane](#l). Many players will overswing trying to reach the blocks and end up punching their HMD.  <details><summary>**Example Image**</summary>![Picture of face puncher](~@images/mapping/facepuncher.png)</details> |
+| **Face Wall** | A [Wall](#wxyz) occupying one of the two center [Lanes](#l). Also known as [Dodge Walls](#d). <details><summary>**Example Image**</summary>![Picture of face wall](~@images/mapping/facewall.jpg)</details> |
 | **Fake Wall** | A [Wall](#wxyz) with a negative width value, making it harmless to the player. |
-| **Fast Wall** | A [Wall](#wxyz) with a negative duration value greater than the map's [Half Jump Duration](#h) that appears to move past the player at a faster speed than normal walls, but slower speed than a [Hyper Wall](#h). |
-| **First Person Flying Control** | A launch option available to SteamVR and Oculus users to launch Beat Saber with limited keyboard and mouse control over the game in a first person view. Very helpful for getting an accurate preview of [Lighting](#l) or [Walls](#wxyz), or accessing the official editor. Abbreviated as [FPFC](#f). |
+| **Fast Wall** | A [Wall](#wxyz) with a negative duration value greater than the map's [Half Jump Duration](#h) that appears to move past the player at a faster speed than normal walls, but at a slower speed than a [Hyper Wall](#h). |
+| **First Person Flying Control** | A launch option available to SteamVR and Oculus users to launch Beat Saber with limited keyboard and mouse control over the game in a first person view. Very helpful for getting an accurate preview of [Lighting](#l) or [Walls](#wxyz), or accessing the official [Editor](#e). Abbreviated as [FPFC](#f). |
 | **Fixed BPM** | A song with a consistent [BPM](#b) from start to finish with no variation. Also known as [Single BPM](#s). See also: [Variable BPM](#uv). |
 | **Flick** | A [Pattern](#p) of two or more [Notes](#n) of the same color, typically at 1/4 precision. <details><summary>**Example Image**</summary>![Picture of flick](~@images/mapping/flick-alt.png)</details> |
-| **Flow** | The concept of placing [Block](#b) [Patterns](#p) so that the next swing a player makes feels natural and allows the body to move in proper ways. |
-| **Forehand** | A swing where the majority of the work is done by the palm side of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. Related: [Backhand](#b). |
-| **FPFC** | Acronym for [First Person Flying Control](#f). |
+| **Flow** | The concept of placing [Blocks](#b) and [Patterns](#p) so that the next swing a player makes feels natural and allows the body to move in proper ways. |
+| **Forehand** | A swing where the majority of the work is done by the palm side of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. See also: [Backhand](#b). |
+| **FPFC** | Abbreviation of [First Person Flying Control](#f). |
 
 ## G
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
@@ -102,7 +103,7 @@ let us know in #mapping-discussion!
 | - | :- |
 | **Half Jump Duration** | The distance down the [Track](#t) where the [Blocks](#b) and [Obstacles](#o) spawn. Measured in beats, therefore varies in "spatial" distance by [BPM](#b). Also known as [Spawn Distance](#s). See also: [Spawn Point](#s), [NJS](#n), [BPM](#b), [Spawn Offset](#s). |
 | **Hammer Hit** | A [Pattern](#p) composed of an [Arrow Block](#a) pointing at a [Bomb](#b), forcing the player to swing their saber at the arrow block but stopping short to avoid the bomb,  making it impossible to get full points. This pattern is highly discouraged. <details><summary>**Example Image**</summary>![Picture of hammer hit](~@images/mapping/hammer-hit-alt.png)</details> |
-| **Handclap** | Any [Pattern](#p) that directs the player's hands inward at each other on the same beat, often leading to the player smashing their hands together. Higher skilled players can sometimes avoid these, but they are still highly discouraged at all levels of mapping. Also known as [Controller Clash/Smash](#c).  <details><summary>**Example Image**</summary>![Picture of handclap](~@images/mapping/controller-smash-alt.png)</details> |
+| **Handclap** | Any [Pattern](#p) that directs the player's hands inward at each other on the same beat, often leading to the player smashing their hands together. Higher skilled players can sometimes avoid these, but they are still highly discouraged at all levels of mapping. Also known as [Controller Clash/Smash](#c). <details><summary>**Example Image**</summary>![Picture of handclap](~@images/mapping/controller-smash-alt.png)</details> |
 | **Hitbox** | The region where the saber collides with an object. [Note](#n) hitboxes are larger than they visually appear, [Bomb](#b) hitboxes are smaller than they visually appear, and [Wall](#wxyz) hitboxes are exactly the size that they visually appear. |
 | **Hitbox Abuse** | [Notes](#n) placed in the pre- or post-swing path of an opposite color note. <details><summary>**Example Image**</summary>![Picture of hitbox abuse](~@images/mapping/hitbox-abuse-alt.png)</details> |
 | **Hook** | A [Pattern](#p) of two sequential up/down [Blocks](#b) of the same color with usually one [Lane](#l) in between. The player's arm makes a hook motion to play this pattern. <details><summary>**Example Image**</summary>![Picture of hook](~@images/mapping/hook.png)</details> |
@@ -112,8 +113,8 @@ let us know in #mapping-discussion!
 ## I
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Info File** | The primary map file that includes information and metadata for all difficulties of a map. In 2.0 song format, this file is a [.dat File](#d). In 1.0 song format, this was a [.json File](#j). See also [Difficulty File](#d). |
-| **Inline** | A [Pattern](#p) that remains in one [Column](#c) and [Row](#r) for two or more blocks in a row. This typically refers to two alternating colors, but not always. <details><summary>**Example Image**</summary>![Picture of inline](~@images/mapping/inline.png)</details> |
+| **Info File** | The primary map file that includes information and metadata for all difficulties of a map. In 2.0 song format, this file is a [.dat File](#d). In 1.0 song format, this is a [.json File](#j). See also: [Difficulty File](#d). |
+| **Inline** | A [Pattern](#p) that remains in one [Column](#c) and [Row](#r) for two or more [Blocks](#b) in a row. This typically refers to two alternating colors, but not always. <details><summary>**Example Image**</summary>![Picture of inline](~@images/mapping/inline.png)</details> |
 | **Inner Ring** | A small ring around the [Track](#t) found in some in-game [Environments](#e). |
 | **Invert** | [Blocks](#b) pointing inwards from the outside requiring a larger pre-swing to hit. <details><summary>**Example Image**</summary>![Picture of invert](~@images/mapping/invert.png)</details> |
 
@@ -135,18 +136,18 @@ let us know in #mapping-discussion!
 | **Lighting** | A collective term for all of the lighting events and options available to mappers. A map is not considered complete without some form of lighting. See also: [Event](#e). |
 | **Lighting Track** | The area in most map editors where [Lighting](#l) events are placed. See also: [Track](#t). |
 | **Lightshow Mode** | A map characteristic where there are no [Blocks](#b), only [Lighting](#l). This mode is not part of the base game and requires the [SongCore](#s) mod. |
-| **Loloppe Notes** | Two same direction [Blocks](#b) placed side-by-side such that hitting both blocks requires abusing the block [Hitbox](#h). Named after the mapper who made them famous. <details><summary>**Example Image**</summary>![Picture of loloppe notes](~@images/mapping/loloppe.png)</details> |
+| **Loloppe Notes** | Two same-direction [Blocks](#b) placed side-by-side such that hitting both blocks requires abusing the block [Hitbox](#h). Named after the mapper who made them famous. <details><summary>**Example Image**</summary>![Picture of loloppe notes](~@images/mapping/loloppe.png)</details> |
 
 ## M
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Map Blindness** | A condition that may occur when a mapper has spent so much time on a map. You know the patterns, you know your intentions. You've self-tested it so many times. Eventually, muscle memory and your subconscious kick in, and you can play the map with your eyes closed, regardless of flaws. See also: [Testplay](#t). |
+| **Map Blindness** | A condition that may occur when a mapper has spent so much time on a map. You know the patterns, you know your intentions, and you've self-tested it so many times. Eventually, muscle memory and your subconscious kick in, and you can play the map with your eyes closed, regardless of flaws. See also: [Playtest](#t). |
 | **Mapping Extensions** | A mod developed by Kyle1314 that allows mappers to access a number of unique utilities for advanced mapping. See also: [Precision Placement](#p), [Precision Rotation](#p), [JSON Walls](#jk). |
-| **Mediocre Map Assistant 2** | A new fork of [Mediocre Mapper](#m) by Assistant. This is the primary map editor used by the mapping community. |
-| **Mediocre Mapper** | An outdated editor, developed by squeaksies as a fork of the original EditSaber editor by Ikiewa. No longer in public development or supported by its author, it has been forked to created [Mediocre Map Assistant 2](#m). |
+| **Mediocre Map Assistant 2** | A new fork of [Mediocre Mapper](#m) by Assistant. This is the primary map [Editor](#e) used by the mapping community. |
+| **Mediocre Mapper** | An outdated editor, developed by squeaksies as a fork of the original EditSaber [Editor](#e) by Ikiewa. No longer in public development or supported by its author, it has been forked to created [Mediocre Map Assistant 2](#m). |
 | **Mine** | A [Block](#b) that looks like a spiky circle that damages the player if their saber touches it. It is safe for a bomb to pass through the player’s body. Also known as [Bomb](#b). |
 | **Mismap** | A mistake, incorrect, or faulty choice in a map. |
-| **Modding** | Modding is a term borrowed from [osu!](#o). It is the process of reviewing and providing feedback for a map via editor and in-game analysis for rankability and/or general improvements. This term is unrelated to game mods that alter the UI or gameplay of Beat Saber. See this [guide](https://bit.ly/ScoreSaberModding) to get started with modding. See also: [Playtest](#p). |
+| **Modding** | Modding is a term borrowed from [osu!](#o). It is the process of reviewing and providing feedback for a map via [editor](#e) and in-game analysis for rankability and/or general improvements. This term is unrelated to game mods that alter the UI or gameplay of Beat Saber. See this [guide](https://bit.ly/ScoreSaberModding) to get started with modding. See also: [Playtest](#p). |
 | **Multiple BPM** | A song with one or more [BPM](#b) changes as intended by the song’s composer. Also known as [Variable BPM](#uv) and [Drifting BPM](#d). See also: [Fixed BPM](#f). |
 
 ## N
@@ -157,31 +158,32 @@ let us know in #mapping-discussion!
 | **No Arrows Mode** | A map characteristic using only [Dot Notes](#d). Often used by new players or for alternate play styles like "maul mode." |
 | **Noodle Extensions** | A more advanced version of [Mapping Extensions](#m) that is only available on PC. |
 | **Note** | A cube with either an arrow or a dot on it. It is the primary element of gameplay. By default, blocks are either red or blue. Also known as [Block](#b). |
-| **Note Jump Speed** | The speed that objects approach the player in-game. Labeled in Info.dat as `_noteJumpMovementSpeed`. Abbreviated [NJS](#n). |
-| **Notes Per Second** | A measure of map density. The number of [Notes](#n) that pass the player within one second. A very rough approximate measure of difficulty. Abbreviated [NPS](#n). |
+| **Note Jump Speed** | The speed that objects approach the player in-game. Labeled in Info.dat as `_noteJumpMovementSpeed`. Abbreviated as [NJS](#n). |
+| **Notes Per Second** | A measure of map density. The number of [Notes](#n) that pass the player within one second. A very rough approximate measure of difficulty. Abbreviated as [NPS](#n). |
 
 ## O
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
 | **Obstacle** | A generic term for both all types of [Walls](#wxyz) and [Bombs](#b). See also: [Wall](#wxyz), [Fake Wall](#f), [Bomb](#b). |
-| **Offset** | A value in milliseconds (ms) used in the map editor to perfectly align the track beat markers with the beat of the music. Song files set up correctly with the [BPM](#b) aligned in an audio editor do not usually need an offset value. |
+| **Offset** | A value in milliseconds (ms) used in the map [Editor](#e) to perfectly align the [Track](#t) beat markers with the beat of the music. Song files set up correctly with the [BPM](#b) aligned in an audio editor do not usually need an offset value. |
 | **.ogg File** | The [OGG Vorbis](https://en.wikipedia.org/wiki/Vorbis) audio file format. |
 | **OHJ** | Abbreviation of [One Handed Jump](#o). |
 | **One Handed Jump** | A sequence of [Jumps](#jk) using only one color. Abbreviated as [OHJ](#o). |
-| **OneSaber Mode** | A map characteristic using only one saber. The left-handed saber disappears completely when playing, unless the player has enabled the Left-Handed option in-game. |
+| **OneSaber Mode** | A map characteristic using only one saber. The left-handed saber disappears completely when playing, unless the player has enabled the *Left-Handed* option in-game. |
 | **osu!** | Another popular rhythm game with a large library of custom maps. Converters exist to translate timings from *osu!* maps into Beat Saber maps. |
 | **Overmapping** | Using multiple [Notes](#n) with different time values to represent a single sound. This does not apply to the extra notes in [Sliders](#s). |
 
 ## P
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Parity** | The mathematical term describing the ‘group’ a [Block](#b) belongs to. Within the context of Beat Saber, this refers to the [Forehand](#f) and [Backhand](#b) nature of a block. |
+| **Parity** | The mathematical term describing the "group" a [Block](#b) belongs to. Within the context of Beat Saber, this refers to the [Forehand](#f) and [Backhand](#b) nature of a block. |
 | **Pattern** | A generic name for a sequence of [Blocks](#b). |
 | **Paul** | A sequence of inline [Blocks](#b) of the same direction placed at very high [Precision](#p). This forces the player to hit the sequence with a slow continuous swing. This [Pattern](#p) is very difficult to score well on. <details><summary>**Example Image**</summary>![Picture of paul](~@images/mapping/paul.jpg)</details> |
 | **Piano Stream** | A sequence of alternating color and direction [Blocks](#b) that progresses horizontally across [Lanes](#l) on the [Track](#t). <details><summary>**Example Image**</summary>![Picture of piano stream](~@images/mapping/pianostream.png)</details> |
-| **Playtest** | The act of playing a WIP map to check for errors and improvements. Highly recommended for a quality product. Also known as [Testplay](#t). |
+| **Pickle** | A [Pattern](#p) where a red and blue [Note](#n) are on opposite-handed sides and are hit simultaneously in opposite directions. Also known as [Pickle](#p). See also: [Crossover Scissor](#s). <details><summary>**Example Image**</summary>![Picture of pickle](~@images/mapping/arm-tangle-alt.png)</details> |
+| **Playtest** | The act of playing a [WIP](#wxyz) map to check for errors and improvements. Highly recommended for creating a quality product. Also known as [Testplay](#t). |
 | **Performance Points** | The metric determining ranking on the [ScoreSaber](#s) leaderboards. Abbreviated as [PP](#p). |
-| **Platform** | The in-game play area, and associated [Track](#t) and [Lighting](#l). Also known as [Environment](#e). |
+| **Platform** | The in-game play area and associated [Track](#t) and [Lighting](#l). Also known as [Environment](#e). |
 | **PP** | Abbreviation of [Performance Points](#p). |
 | **Precision** | The musical duration of the spacing between [Notes](#n). Typically 1/1 (one note per beat), 1/2 (one note per half beat), or 1/4 (one note per quarter beat). Also known as [Cursor Precision](#c). |
 | **Precision Placement** | A style of mapping that requires [Mapping Extensions](#m), which allows the mapper to place [Blocks](#b) outside of the standard 4x3 grid. Not recommended for novice mappers. |
@@ -195,24 +197,25 @@ let us know in #mapping-discussion!
 ## R
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Ranked** | A map that has been [Modded](#m) and approved by the [ScoreSaber](#s) ranking team as having a quality appropriate of contributing to the [PP](#p) leaderboard. Maps should be modded prior to submitting a rank request. |
+| **Ranked** | A map that has been [Modded](#m) and approved by the [ScoreSaber](#s) ranking team as having a quality appropriate of contributing to the [Performance Points](#p) leaderboard. Maps should be modded prior to submitting a rank request. |
 | **Release** | The act of publishing a finished map on [BeatSaver](#b). Once a map is released, it can be downloaded and played by anyone. Do not release unfinished or untested maps. |
 | **Reset** | The action of bringing your arms back to their "ready" position, as if no [Blocks](#b) have been hit recently. Mappers can also attempt to reset the player by using [Bombs](#b) to force arm movement. See also: [Bomb Reset](#b). |
 | **RGB** | A style of [Lighting](#l) that requires the [Chroma](#c) mod and allows lighting events to be of any color and to use more than two colors. |
-| **Right Triangle** | A variation of a [Triangle](#t) where there is a 90 degree hit in the sequence causing major comfort issues at lower [Precision](#p). <details><summary>**Example Image**</summary>![Picture of right triangle](~@images/mapping/right-triangle.jpg)</details> |
+| **Right Triangle** | A variation of a [Triangle](#t) where there is a 90 degree hit in the sequence causing major comfort issues at lower [Precisions](#p). <details><summary>**Example Image**</summary>![Picture of right triangle](~@images/mapping/right-triangle.jpg)</details> |
 | **Righty Stream** | A straight [Stream](#s) where each pair of successive [Notes](#n) going in the same direction starts with the right hand. See also: [Lefty Stream](#l). <details><summary>**Example Image**</summary>![Picture of righty stream](~@images/mapping/righty-stream.jpg)</details> |
 | **Row** | Vertical divisions above the [Track](#t) in which [Blocks](#b) travel. The default track has three layers, commonly referred to as bottom, middle, and top. Also known as [Layer](#l). See also: [Lane](#l), [Column](#c). |
 
 ## S
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **ScoreSaber** | The organization responsible for managing the ranked Beat Saber leaderboards. The Beat Saber leaderboards website can be found [here](https://scoresaber.com/). |
+| **ScoreSaber** | The organization responsible for managing the ranked Beat Saber leaderboards. The Beat Saber leaderboards website can be found [here](https://scoresaber.com/). See also: [Performance Points](#p). |
 | **Scissor** | When a red and blue [Note](#n) are on the same timing, and are hit simultaneously in opposite directions. Also known as [Cucumber](#c). See also: [Crossover Scissor](#c). <details><summary>**Example Image**</summary>![Picture of scissor](~@images/mapping/scissor-cucumber_example.png)</details> |
 | **Scoop** | A [Pattern](#p) of [Blocks](#b) where the player makes a "scooping" motion to play the pattern. Typically a left or right note followed by an up note in the bottom row. Give the player an ample amount of time to react when using scoops - a half to full beat is recommended. <details><summary>**Example Image**</summary>![Picture of scoop](~@images/mapping/scoop_example.png)</details> |
 | **Setup** | The process of maneuvering the player's arms into position for a [Pattern](#p) via appropriate placement of the preceding [Blocks](#b). |
 | **Single** | A single [Block](#b) hit with one saber. Typically makes up the majority of [Patterns](#p) in a map. See also: [Double](#d). |
-| **Single BPM** | A song with a consistent [BPM](#b) from start to finish with no variation. Also known as [Fixed BPM](#f). See also [Variable BPM](#uv). |
+| **Single BPM** | A song with a consistent [BPM](#b) from start to finish with no variation. Also known as [Fixed BPM](#f). See also: [Variable BPM](#uv). |
 | **Sliders** | A series of same-colored [Dot Notes](#d) or [Arrow Blocks](#a) spaced close enough together for the player to sweep the saber through in one motion. Placed at a [Precision](#p) of 1/12 or faster. <details><summary>**Example Image**</summary>![Picture of sliders](~@images/mapping/sliders.png)</details> |
+| **SongCore** | A mod for handling custom song additions in Beat Saber. |
 | **Spawn Distance** | The distance down the [Track](#t) where the [Blocks](#b) and [Obstacles](#o) spawn. Measured in beats, therefore varies in "spatial" distance by [BPM](#b). Also known as [Half Jump Duration](#h). See also: [Spawn Point](#s), [NJS](#n), [BPM](#b), [Spawn Offset](#s). |
 | **Spawn Distance Modifier** | A variable denoted as `_noteJumpStartBeatOffset` in the map's [Info File](#i) that modifies the [Spawn Distance](#d). Can be a floating value, typically between -1.0 and 1.0. Also known as [Spawn Offset](#s).
 | **Spawn Offset** | A variable denoted as `_noteJumpStartBeatOffset` in the map's [Info File](#i) that modifies the [Spawn Distance](#d). Can be a floating value, typically between -1.0 and 1.0. Also known as [Spawn Distance Modifier](#s). |
@@ -223,26 +226,26 @@ let us know in #mapping-discussion!
 | **Staircase** | A [Pattern] where a [Block](#s)'s direction points towards the following block. This does not include blocks on the same beat. Can be a potential [Hitbox](#h) issue where a block is placed in the post-swing of a previous block. <details><summary>**Example Image**</summary>![Picture of staircase](~@images/mapping/staircase.jpg)</details> |
 | **Stream** | A steady, sustained [Pattern](#p) of [Notes](#n), typically at 1/4 [Precision](#p). <details><summary>**Example Image**</summary>![Picture of stream](~@images/mapping/stream.png)</details> |
 | **Strobe** | 1) *noun*. A rapidly flashing on/off light. <br> 2) *verb*. To cause a light to flash on/off or flicker when [Lighting](#l) a map. |
-| **Swings Per Second** | A variation on [Notes per second](#n) that is not inflated by lots of [Sliders](#s). This metric can give a better representation of a map's difficulty. |
+| **Swings Per Second** | A variation on [Notes Per Second](#n) that is not inflated by use of [Sliders](#s). This metric can give a better representation of a map's difficulty. |
 
 ## T
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
 | **Tangle** | A [Pattern](#p) that results in arm paths preventing the next motion from occurring without [Resetting](#r). This occurs commonly in incorrect [Crossovers](#c). |
 | **Tempo** | A musical term for the speed of music. The tempo can change throughout the duration of a song. |
+| **Testplay** | The act of playing a [WIP](#wxyz) map to check for errors and improvements. Highly recommended for creating a quality product. Also known as [Playtest](#p). |
 | **Thin Wall** | A [Wall](#wxyz) that is only a tiny fraction of a beat long that sometimes does not cause any damage to the player. Created in [Mediocre Map Assistant 2](#m) by clicking to add a wall then immediately clicking to "drop" it, without scrolling for any time duration. See also: [Wall](#wxyz), [Fake Wall](#f). <details><summary>**Example Image**</summary>![Picture of thin wall](~@images/mapping/thinwall.png)</details> |
 | **Tower** | Three same-colored, same-direction [Blocks] placed in a line on the same beat. Results in the player swinging a larger, faster hit. See also: [Stack](#s). <details><summary>**Example Image**</summary>![Picture of tower](~@images/mapping/tower.jpg)</details>|
-| **Track** | The area in an editor where [Blocks](#b) are placed and the area in-game where blocks spawn and move towards the player. In most editors, there is a track for notes/blocks and a separate track for [Lighting](#l). See also: [Lighting Track](#l). |
-| **Triangle** | Three or more [Notes](#n) forming a "triangle" pattern with position and orientation, causing a [Wrist Reset](#wxyz), especially if used in high [Precision](#p) (under 1/1). <details><summary>**Example Image**</summary>![Picture of triangle](~@images/mapping/triangle.png)</details> |
+| **Track** | The area in an [Editor](#e) where [Blocks](#b) are placed and the area in-game where blocks spawn and move towards the player. In most editors, there is a track for blocks and a separate track for [Lighting](#l). See also: [Lighting Track](#l). |
+| **Triangle** | Three or more [Notes](#n) forming a "triangle" [Pattern](#p) with position and orientation, causing a [Wrist Reset](#wxyz), especially if used in high [Precision](#p) (under 1/1). <details><summary>**Example Image**</summary>![Picture of triangle](~@images/mapping/triangle.png)</details> |
 
 ## UV
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Variable BPM** | 1) A song with an intentionally shifting [BPM](#b) as intended by its composer. <br> 2) A song with irregular, unintentionally shifting BPM as a result of fluctuations; for example, a live performance without a metronome (definition provided by [ScoreSaber](#s)'s Ranking Criteria). <br> Also known as [Drifting BPM](#d) and [Multiple BPM](#m). See also: [Fixed BPM](#f). |
+| **Variable BPM** | 1) A song with an intentionally shifting [BPM](#b) as intended by its composer. <br> 2) A song with irregular, unintentionally shifting BPM as a result of fluctuations. For example, a live performance without a metronome (example provided by [ScoreSaber](#s)'s Ranking Criteria). <br> Also known as [Drifting BPM](#d) and [Multiple BPM](#m). See also: [Fixed BPM](#f). |
 | **VB** | Abbeviation of [Vision Block](#uv). |
-| **Vibro** | An extremely high speed [Stream](#s) of a pace requiring small wrist motions to hit, typically at 1/8 [Precision](#p). Note that this does NOT apply to [Dot Notes](#d). Also known as [Vibro Stream](#uv). <details><summary>**Example Image**</summary>![Picture of vibro](~@images/mapping/vibro.jpg)</details> |
-| **Vibro Stream** | An extremely high speed [Stream](#s) of a pace requiring small wrist motions to hit, typically at 1/8 [Precision](#p). Note that this does NOT apply to [Dot Notes](#d). Also known as [Vibro](#uv). <details><summary>**Example Image**</summary>![Picture of vibro](~@images/mapping/vibro.jpg)</details> |
-| **Vision Block** | A sequence of [Blocks](#b), typically using the middle [Row](#r), that blocks the player’s vision of the following notes. The most common form of vision blocks are [Face Notes](#f), but blocks outside of the center two squares can also block line of sight to later blocks. Abbreviated as [VB](#uv). <details><summary>**Example Image**</summary>![Picture of vision block](~@images/mapping/vb_example.png)</details> |
+| **Vibro Stream** | An extremely high speed [Stream](#s) of a pace requiring small wrist motions to hit, typically at 1/8 [Precision](#p). Note that this does not apply to [Dot Notes](#d). Referred to as either *Vibro* or *Vibro Stream*. <details><summary>**Example Image**</summary>![Picture of vibro](~@images/mapping/vibro.jpg)</details> |
+| **Vision Block** | A sequence of [Notes](#n), typically using the middle [Row](#r), that block the player’s vision of the following notes. The most common form of vision blocks are [Face Notes](#f), but blocks outside of the center two squares can also block line of sight to later blocks. Abbreviated as [VB](#uv). <details><summary>**Example Image**</summary>![Picture of vision block](~@images/mapping/vb_example.png)</details> |
 
 ## WXYZ
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |

--- a/wiki/mapping/glossary.md
+++ b/wiki/mapping/glossary.md
@@ -16,233 +16,239 @@ let us know in #mapping-discussion!
 ## A
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **3-Wide Wall** | A *wall* that spans 3 lanes, requiring the player to move out of the center of the *track* to avoid. Interchangeably used with any wall requiring the player to move out of the center of the track. Never considered okay to use. |
-| **360 Mode** | A map characteristic that allows the track to rotate in 15 degree increments in a full circle. As of January 2021 these maps can only be made in ChroMapper and in the official editor. |
-| **4-Wide Wall** | A *wall* that spans all four lanes and three rows of the standard *track*, usually causing the player to fail the level unless it is thin. Never considered okay to use. |
-| **90 Mode** | A map characteristic that allows the track to rotate in 15 degree increments up to 45 degrees in either direction. As of January 2021 these maps can only be made in ChroMapper and in the official editor. |
-| **Arrow Block** | A *block* with an arrow on it indicating the direction in which it must be hit. Also known as [Arrow Note](#a). See also [Block](#b), [Note](#n), [Dot Block/Note](#d) <details><summary>**Example Image**</summary>![Picture of Arrow Blocks](~@images/mapping/arrowblocks.jpg)</details>|
-| **Arrow Vortex** | The name of a free third party tool that can analyze song *BPM* and calculate *offset*. Download and guide on use is available [here](./basic-audio.md#tool-assisted-bpm-calculation). |
+| **3-Wide Wall** | A [Wall](#wxyz) that spans three [Lanes](#l), requiring the player to move out of the center of the [Track](#t) to avoid. The term is interchangeably used with any wall requiring the player to move out of the center of the track. This is considered never okay to use. |
+| **360 Mode** | A map characteristic that allows the [Track](#t) to rotate in 15 degree increments in a full circle. As of January 2021, these maps can only be made in ChroMapper and in the official editor. |
+| **4-Wide Wall** | A [Wall](#wxyz) that spans all four [Lanes](#l) and three [Rows](#r) of the standard [Track](#t), usually causing the player to fail the level unless the wall is thin. This is considered never okay to use. |
+| **90 Mode** | A map characteristic that allows the track to rotate in 15 degree increments, up to 45 degrees in either direction from the center. As of January 2021, these maps can only be made in ChroMapper and in the official editor. |
+| **Arrow Block/Note** | A [Block](#b) with an arrow on it indicating the direction in which it must be hit. Also known as *Arrow Note*. See also: [Block](#b), [Note](#n), [Dot Block/Note](#d). <details><summary>**Example Image**</summary>![Picture of arrow blocks](~@images/mapping/arrowblocks.jpg)</details>|
+| **Arrow Vortex** | A free third party tool that can analyze a song's [BPM](#b) and calculate its [Offset](#o). The download and a guide on how to use the tool is available [here](./basic-audio.md#tool-assisted-bpm-calculation). |
 
 ## B
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Backhand** | A swing where the majority of the work is done by the back of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. Related: [Forehand](#f) |
-| **Beats per Minute** | Defines the *tempo* (speed) of a song. The number of beats that occur in one minute. Abbreviated *BPM* |
-| **BeatSaver** | The repository for all custom songs in Beat Saber. Songs uploaded here feed automatically to Beast Saber. The link can be found [here.](https://beatsaver.com/) |
-| **Block** | A cube with either an arrow or dot on it. The primary element of gameplay. By default, blocks are red or blue. Also known as [Note](#n) <details><summary>**Example Image**</summary>![Picture of block](~@images/mapping/arrow-block.png)</details>|
-| **BPM** | Acronym for *Beats per Minute*. |
-| **Bomb** | A *block* that looks like a spiky circle and that damages the player if their saber touches it. It is safe for a bomb to pass through the player’s body. Also known as [Mine](#m) <details><summary>**Example Image**</summary>![Picture of bomb](~@images/mapping/bomb.png)</details>|
-| **Bomb Reset** | A pattern of *bombs* placed to forcibly reset the player’s arms. See also [Reset](#r) <details><summary>**Example Image**</summary>![Picture of bomb reset](~@images/mapping/bombreset.jpg)</details>|
-| **Bomb Spiral/Helix** | A pattern of *bombs* placed in a spiral or helical pattern, intended to force the player to move their arms in a large circle. <details><summary>**Example Image**</summary>![Picture of bomb spiral](~@images/mapping/bombspiral.jpg)</details> |
+| **Backhand** | A swing where the majority of the work is done by the back of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. See also: [Forehand](#f). |
+| **Beats Per Minute** | The number of beats that occur in one minute, defining the [Tempo](#t) of a song. Also known as [BPM](#b). |
+| **BeastSaber** | A website that categorizes the songs uploaded to [BeatSaver](#b) into different genres and attribute tags. Players can review songs and comment on them. A team of curators plays through many songs each day and recommends the ones that stand out. Also known as *BSaber*. The link can be found [here](https://bsaber.com/). |
+| **BeatSaver** | The repository for all custom songs in Beat Saber. Songs uploaded here feed automatically to [Beast Saber](#b). The link can be found [here](https://beatsaver.com/). |
+| **Block** | A cube with either an arrow or a dot on it. It is the primary element of gameplay. By default, blocks are either red or blue. Also known as [Note](#n). <details><summary>**Example Image**</summary>![Picture of block](~@images/mapping/arrow-block.png)</details> |
+| **BPM** | Acronym for [Beats Per Minute](#b). |
+| **Bomb** | A [Block](#b) that looks like a spiky circle that damages the player if their saber touches it. It is safe for a bomb to pass through the player’s body. Also known as [Mine](#m). <details><summary>**Example Image**</summary>![Picture of bomb](~@images/mapping/bomb.png)</details> |
+| **Bomb Reset** | [Bombs](#b) placed to forcibly reset the player’s arms. See also [Reset](#r). <details><summary>**Example Image**</summary>![Picture of bomb reset](~@images/mapping/bombreset.jpg)</details> |
+| **Bomb Spiral/Helix** | [Bombs](#b) placed in a spiral or helical [Pattern](#p), intended to force the player to move their arms in a large circle. <details><summary>**Example Image**</summary>![Picture of bomb spiral](~@images/mapping/bombspiral.jpg)</details> |
 
 ## C
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Chroma** | A mod that makes custom lighting *events* available to mappers, most notably allowing for full RGB color mapping. Chroma lights can be viewed with both the core Chroma mod and the smaller ChromaLite mod. |
-| **Columns** | Horizontal divisions across the *track* down which blocks travel. The default track has four columns. Also known as [Lane](#l). See also: [Row](#r), [Layer](#l) |
-| **Controller Clash/Smash** | Any pattern that directs the players hands inward at each other on the same beat, often leading to the player smashing their hands together. Higher skilled players can sometimes avoid these but they’re still highly discouraged at all levels of mapping. Also known as [Handclap](#h) <details><summary>**Example Image**</summary>![Picture of controller clash](~@images/mapping/controller-smash-alt.png)</details> |
-| **Corner Crouch** | The combination of a *dodge wall* and a *crouch wall* leave the player a small gap to squeeze into. <details><summary>**Example Image**</summary>![Picture of corner crouch](~@images/mapping/corner-crouch-alt.png)</details>|
-| **Cover Image** | The square image associated with the song loaded into the song browser. Must be a minimum of 256x256 pixels but not recommended to be more than 512x512 pixels. |
-| **Crouch Wall** | A *wall* blocking the upper portion of the playspace which forces the player to crouch to avoid.  <details><summary>**Example Image**</summary>![Picture of corner crouch](~@images/mapping/crouch.jpg)</details>|
-| **Croissant** | A stream pattern that has the player swing making a X. The name is due to its shape and being very comfortable, or "tasty". <details><summary>**Example Image**</summary>![Picture of Croissant](~@images/mapping/croissant-pattern.png)</details>|
-| **Crossover** | A *block* placed on its opposite-handed side. Example: A blue block placed in lanes one or two, or a red block placed in lanes three or four, primarily when the pattern forces the players’ arms to "cross over" to play. <details><summary>**Example Image**</summary>![Picture of crossover](~@images/mapping/crossover.png)</details>|
-| **Crossover Scissor** | Otherwise known as a *Pickle*, is when a red and blue note are on the opposite-handed side and are hit simultaneously in opposite directions. Related: [Scissor](#s) <details><summary>**Example Image**</summary>![Picture of crossover scissor](~@images/mapping/arm-tangle-alt.png)</details> |
-| **Cucumber** | Otherwise known as a *Scissor*, is when a red and blue note are on the same timing, and are hit simultaneously in opposite directions. Related: [Crossover Scissor](#c) <details><summary>**Example Image**</summary>![Picture of scissor](~@images/mapping/scissor-cucumber_example.png)</details>
-| **Cursor Precision** | The musical duration of the spacing between *notes*. Typically 1/1 (one note per beat), 1/2 (one note per half beat), or 1/4 (one note per quarter beat). Also known as [Precision](#p) |
+| **Chroma** | A mod that makes custom lighting [Events](#e) available to mappers, most notably allowing for full RGB color mapping. Chroma lights can be viewed by either the core Chroma mod or the smaller ChromaLite mod. |
+| **Column** | Horizontal divisions across the [Track](#t) in which [Blocks](#b) travel. The default track has four columns. Also known as [Lane](#l). See also: [Row](#r), [Layer](#l). |
+| **Controller Clash/Smash** | Any [Pattern](#p) that directs the player's hands inward at each other on the same beat, often leading to the player smashing their hands together. Higher skilled players can sometimes avoid these, but they are still highly discouraged at all levels of mapping. Also known as [Handclap](#h). <details><summary>**Example Image**</summary>![Picture of controller clash](~@images/mapping/controller-smash-alt.png)</details> |
+| **Corner Crouch** | A wall [Pattern](#p) that combines a [Dodge Wall](#d) and a [Crouch Wall](#c), leaving the player a small gap to squeeze into. <details><summary>**Example Image**</summary>![Picture of corner crouch](~@images/mapping/corner-crouch-alt.png)</details> |
+| **Cover Image** | The square image associated with the song loaded into the song browser. Must be a minimum of 256x256 pixels, but not recommended to be more than 512x512 pixels. |
+| **Crouch Wall** | A [Wall](#wxyz) blocking the upper portion of the playspace which forces the player to crouch to avoid. <details><summary>**Example Image**</summary>![Picture of corner crouch](~@images/mapping/crouch.jpg)</details> |
+| **Croissant** | A [Stream](#s) [Pattern](#p) that has the player swing in the shape of an X. The name is due to its shape and being very comfortable, or "tasty". <details><summary>**Example Image**</summary>![Picture of croissant](~@images/mapping/croissant-pattern.png)</details> |
+| **Crossover** | A [Block](#b) placed on its opposite-handed side. For example, a blue block placed in lanes one or two, or a red block placed in lanes three or four, primarily when the pattern forces the player's arms to "cross over" to play. <details><summary>**Example Image**</summary>![Picture of crossover](~@images/mapping/crossover.png)</details> |
+| **Crossover Scissor** | A [Pattern](#p) where a red and blue [Note](#n) are on opposite-handed sides and are hit simultaneously in opposite directions. Also known as *Pickle*. See also: [Scissor](#s). <details><summary>**Example Image**</summary>![Picture of crossover scissor](~@images/mapping/arm-tangle-alt.png)</details> |
+| **Cucumber** | When a red and blue [Note](#n) are on the same timing, and are hit simultaneously in opposite directions. Also known as [Scissor](#s). See also: [Crossover Scissor](#c). <details><summary>**Example Image**</summary>![Picture of scissor](~@images/mapping/scissor-cucumber_example.png)</details> |
+| **Cursor Precision** | The musical duration of the spacing between [Notes](#n). Typically 1/1 (one note per beat), 1/2 (one note per half beat), or 1/4 (one note per quarter beat). Also known as [Precision](#p). |
 
 ## D
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **.dat File** | The text file containing most content for that difficulty or song info in the new 2.0 song format. Contains json format with different structure to 1.0, and a different file extension. File format is used for both song info and for map content. See also [Info File](#i), [Difficulty File](#d)  |
-| **Difficulty File** | The *.dat* text file containing most content for that difficulty. In the old, obsolete song format this was a *.json file*. |
-| **Dodge Wall** | A vertical *wall* that forces the player to move out of the way to avoid taking damage. See also [Groove Wall](#g), [Crouch Wall](#c) <details><summary>**Example Image**</summary>![Picture of dodge wall](~@images/mapping/dodgewall.jpg)</details>|
-| **Dot Block/Note** | A block that can be hit from any direction. Often used as top notes in lower difficulty maps or in sliders. Also known as [Dot Notes](#d) <details><summary>**Example Image**</summary>![Picture of dot note](~@images/mapping/bndot.png)</details>|
-| **Dot Spam** | Overuse of dot blocks in a single or two adjacent rows, typically due to inexperience. See also [Dot Block/Note](#d) <details><summary>**Example Image**</summary>![Picture of dot spam](~@images/mapping/dotspam.png)</details>|
-| **Double Directionals (DD)** | Two sequential same colored blocks with the same or close orientations. Typically considered for blocks within angles of 45 degrees of each other. The playability of this pattern depends on the amount of time given to players to reset. Discouraged within 1.5 beats (longer in higher BPM songs). Also known as Drumsticking (dated) <details><summary>**Example Image**</summary>![Picture of double diretionals](~@images/mapping/double-directionals.jpg)</details>|
-| **Doubles** | Two different colored notes on the same timing, hit simultaneously. <details><summary>**Example Image**</summary>![Picture of doubles](~@images/mapping/doubles.jpg)</details>|
-| **Drumsticking** | Two sequential same colored blocks with the same or close orientations. Dated term for Double Directionals |
-| **Drifting BPM** | An unintentionally shifting song BPM as a result of live performance without a metronome. Also known as [Variable BPM](#uv) and [Multiple BPM](#m). See also [Fixed BPM](#f) |
+| **.dat File** | The text file containing most content for a certain difficulty or song info in the new 2.0 song format. It contains JSON format with a different structure compared to 1.0, and a different file extension. This file format is used for both song info and for map content. See also: [Info File](#i), [Difficulty File](#d). |
+| **Difficulty File** | The [.dat File](#d) containing most content for that difficulty. In the old, obsolete song format, this was a [.json File](#j). |
+| **Dodge Wall** | A vertical [Wall](#wxyz) that forces the player to move out of the way to avoid taking damage. See also: [Groove Wall](#g), [Crouch Wall](#c). <details><summary>**Example Image**</summary>![Picture of dodge wall](~@images/mapping/dodgewall.jpg)</details> |
+| **Dot Block/Note** | A [Block](#b) that can be hit from any direction. Often used as top notes in lower difficulty maps or in [Sliders](#s). Also known as [Dot Notes](#d). <details><summary>**Example Image**</summary>![Picture of dot note](~@images/mapping/bndot.png)</details> |
+| **Dot Spam** | A [Pattern](#p) that overuses [Dot Blocks](#d) in a single or two adjacent rows, typically due to inexperience. See also: [Dot Block/Note](#d). <details><summary>**Example Image**</summary>![Picture of dot spam](~@images/mapping/dotspam.png)</details> |
+| **DD** | Acronym for [Double Directional](#d). |
+| **Double Directional** | A [Pattern](#p) where two sequential same colored [Blocks](#b) have the same or close orientation, typically considered for blocks within 45 degree angles of each other. The playability of this pattern depends on the amount of time given to players to [Reset](#r). This pattern is discouraged within 1.5 beats (or longer in higher [BPM](#b) songs). Abbreviated as *DD*. Also known as [Drumsticking](#d) (term outdated). <details><summary>**Example Image**</summary>![Picture of double directionals](~@images/mapping/double-directionals.jpg)</details> |
+| **Double** | A [Pattern](#p) of two different colored [Notes](#n) on the same timing and hit simultaneously. <details><summary>**Example Image**</summary>![Picture of doubles](~@images/mapping/doubles.jpg)</details> |
+| **Drumsticking** | A [Pattern](#p) where two sequential same colored [Blocks](#b) have the same or close orientation. This term is outdated. Also known as [Double Directional](#d). |
+| **Drifting BPM** | An unintentionally shifting song [BPM](#b) as a result of a live performance without a metronome. Also known as [Variable BPM](#uv) and [Multiple BPM](#m). See also: [Fixed BPM](#f). |
 
 ## E
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
 | **Editor** | A generic name for any of the map editors available. |
-| **.egg File** | A version of an .ogg song file used by BeatSaver. Mappers do not need to worry about this. |
-| **Environment** | The in-game play area and associated platform, track, and lights. Also known as [Platform](#p). |
-| **Error Checker** | A feature in Mediocre Map Assistant 2 that allows mappers to check for the presence of double directionals, vision blocks, and stacked notes. |
-| **Escape** | The notes following a block. Complex crossovers or obstacle patterns require carefully considered escape patterns to feel comfortable. |
+| **.egg File** | A version of an [.ogg File](#o) used by [BeatSaver](#b). Mappers do not need to worry about this. |
+| **Environment** | The in-game play area and associated [Platform](#p), [Track](#t), and [Lighting](#l). Also known as [Platform](#p). |
+| **Error Checker** | A feature in [Mediocre Map Assistant 2](#m) that allows mappers to check for the presence of [Double Directionals](#d), [Vision Blocks](#uv), and stacked notes. |
+| **Escape** | The process of maneuvering the player's arms to conclude a [Pattern](#p). Complex [Crossovers](#c) or [Obstacle](#o) patterns require carefully considered escape patterns to feel comfortable. See also: [Setup](#s). |
 | **Event** | Any non-interactable element occurrence processed by the game. |
 
 ## F
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Face Bombs** | Bombs placed in the center two positions of the track. Very easily hit by the hilt of the saber even when the player has arms outstretched. <details><summary>**Example Image**</summary>![Picture of face bomb](~@images/mapping/facebomb.jpg)</details>|
-| **Face Note** | Blocks placed in the center two positions of the track (lanes/columns two and three, middle layer/row). These blocks will be at the player’s head/face level if their height is set correctly and are highly discouraged. <details><summary>**Example Image**</summary>![Picture of face note](~@images/mapping/facenote.jpg)</details>|
-| **Face Puncher** | A pattern that consists of one or two diagonal up blocks crossed over into the extreme opposite lane. Many players will overswing trying to reach and end up punching their HMD.  <details><summary>**Example Image**</summary>![Picture of face puncher](~@images/mapping/facepuncher.png)</details>|
-| **Face Wall** | Wall occupying one of the two center lanes. Also known as [Dodge Walls](#d). <details><summary>**Example Image**</summary>![Picture of face wall](~@images/mapping/facewall.jpg)</details>|
-| **Fake Wall** | Wall with a negative width value, making it harmless to the player. |
-| **Fast Walls** | Walls with a negative duration value greater than the map's [Half Jump Duration](#h) that appear to move past the player at a slower speed than [Hyper Walls](#h). |
-| **First Person Flying Control** | A launch option available to SteamVR and Oculus users to launch Beat Saber and have limited keyboard and mouse control over the game in a first person view. Very helpful for getting an accurate preview of lighting or walls or accessing the official editor. Abbreviated FPFC |
-| **Fixed BPM** | A song with a consistent BPM from start to finish with no variation. Also known as [Single BPM](#s). See also [Variable BPM](#uv) |
-| **Flick** | A pattern of two or more notes of the same color, typically at 1/4 precision. <details><summary>**Example Image**</summary>![Picture of flick](~@images/mapping/flick-alt.png)</details>|
-| **Flow** | The concept of placing block patterns so that the next swing a player makes feels natural and allows the body to move in proper ways. |
-| **Forehand** | A swing where the majority of the work is done by the palm side of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. Related: [Backhand](#b) |
-| **FPFC** | Acronym for First Person Flying Control |
+| **Face Bomb** | [Bombs](#b) placed in the center two positions of the [Track](#t). Very easily hit by the hilt of the saber even when the player has their arms outstretched. <details><summary>**Example Image**</summary>![Picture of face bomb](~@images/mapping/facebomb.jpg)</details> |
+| **Face Note** | [Blocks](#b) placed in the center two positions of the [Track](#t). These blocks will be at the player’s face level if their height is set correctly, and are highly discouraged due to potentially causing [Vision Blocks](#uv). <details><summary>**Example Image**</summary>![Picture of face note](~@images/mapping/facenote.jpg)</details> |
+| **Face Puncher** | A [Pattern](#p) that consists of one or two diagonal up [Blocks](#b) crossed over into the extreme opposite [Lane](#l). Many players will overswing trying to reach the blocks and end up punching their HMD.  <details><summary>**Example Image**</summary>![Picture of face puncher](~@images/mapping/facepuncher.png)</details> |
+| **Face Wall** | A [Wall](#wxyz) occupying one of the two center lanes. Also known as [Dodge Walls](#d). <details><summary>**Example Image**</summary>![Picture of face wall](~@images/mapping/facewall.jpg)</details> |
+| **Fake Wall** | A [Wall](#wxyz) with a negative width value, making it harmless to the player. |
+| **Fast Wall** | A [Wall](#wxyz) with a negative duration value greater than the map's [Half Jump Duration](#h) that appears to move past the player at a faster speed than normal walls, but slower speed than a [Hyper Wall](#h). |
+| **First Person Flying Control** | A launch option available to SteamVR and Oculus users to launch Beat Saber with limited keyboard and mouse control over the game in a first person view. Very helpful for getting an accurate preview of [Lighting](#l) or [Walls](#wxyz), or accessing the official editor. Abbreviated as [FPFC](#f). |
+| **Fixed BPM** | A song with a consistent [BPM](#b) from start to finish with no variation. Also known as [Single BPM](#s). See also: [Variable BPM](#uv). |
+| **Flick** | A [Pattern](#p) of two or more [Notes](#n) of the same color, typically at 1/4 precision. <details><summary>**Example Image**</summary>![Picture of flick](~@images/mapping/flick-alt.png)</details> |
+| **Flow** | The concept of placing [Block](#b) [Patterns](#p) so that the next swing a player makes feels natural and allows the body to move in proper ways. |
+| **Forehand** | A swing where the majority of the work is done by the palm side of the hand. See this clip in [Fru's Tutorial Video](https://youtu.be/t9AFj4pfptM?t=454) for more info. Related: [Backhand](#b). |
+| **FPFC** | Acronym for [First Person Flying Control](#f). |
 
 ## G
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Gallops** | A rapid pattern of two singles followed by a double. Significantly difficult to play and discouraged at high tempos and high precision. Can also add unintended emphasis. <details><summary>**Example Image**</summary>![Picture of gallop](~@images/mapping/gallop.png)</details>|
-| **Groove Wall** | A wall that is paired with a note that creates a motion involving both arms and body. See also [Dodge Wall](#d), [Crouch Wall](#c) <details><summary>**Example Image**</summary>![Picture of groove wall](~@images/mapping/groovewall.jpg)</details>|
+| **Gallop** | A rapid [Pattern](#p) of two single [Notes](#n) followed by a [Double](#d). Significantly difficult to play, and discouraged at high [Tempos](#t) and high [Precision](#p). This pattern can also add unintended emphasis. <details><summary>**Example Image**</summary>![Picture of gallop](~@images/mapping/gallop.png)</details> |
+| **Groove Wall** | A [Wall](#wxyz) that is paired with a [Note](#n) that creates a motion involving both arms and body. See also: [Dodge Wall](#d), [Crouch Wall](#c). <details><summary>**Example Image**</summary>![Picture of groove wall](~@images/mapping/groovewall.jpg)</details> |
 
 ## H
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Half Jump Duration** | The distance down the track where the blocks and obstacles spawn. Measured in beats; therefore varies in "spatial" distance by BPM . Also known as [Spawn Distance](#s). See also [Spawn Point](#s), [NJS](#n), [BPM](#b), and [Spawn Offset](#s).  |
-| **Hammer Hit** | A pattern composed of an arrow block pointing at a bomb, forcing the player to swing their saber at the block but stop short to avoid the bomb and making it impossible to get full points. Highly discouraged pattern. <details><summary>**Example Image**</summary>![Picture of hammer hit](~@images/mapping/hammer-hit-alt.png)</details> |
-| **Handclap** | Any pattern that directs the players hands inward at each other on the same beat, often leading to the player smashing their hands together. Higher skilled players can sometimes avoid these but they’re still highly discouraged at all levels of mapping. Also known as [Controller Clash](#c), [Controller Smash](#c)  <details><summary>**Example Image**</summary>![Picture of handclap](~@images/mapping/controller-smash-alt.png)</details> |
-| **Hitbox** | The region where the saber collides with an object. Note hitboxes are larger than they visually appear, bomb hitboxes are smaller than they appear, and wall hitboxes are exact |
-| **Hitbox abuse** | Notes placed in the pre or post swing path of an opposite color note. <details><summary>**Example Image**</summary>![Picture of hitbox abuse](~@images/mapping/hitbox-abuse-alt.png)</details> |
-| **Hook** | A pattern of two sequential up/down blocks of the same color with usually one lane in between. The players arm makes a hook motion to play the pattern. <details><summary>**Example Image**</summary>![Picture of hook](~@images/mapping/hook.png)</details>|
-| **Hot Start** | When the first notes of a map appear within two seconds of the beginning of the song. |
-| **Hyper Walls** | Wall with a negative duration value lower than the map's [Half Jump Duration](#h) that appears to move past the player at an even faster speed than [Fast Walls](#f). |
+| **Half Jump Duration** | The distance down the [Track](#t) where the [Blocks](#b) and [Obstacles](#o) spawn. Measured in beats, therefore varies in "spatial" distance by [BPM](#b). Also known as [Spawn Distance](#s). See also: [Spawn Point](#s), [NJS](#n), [BPM](#b), [Spawn Offset](#s). |
+| **Hammer Hit** | A [Pattern](#p) composed of an [Arrow Block](#a) pointing at a [Bomb](#b), forcing the player to swing their saber at the arrow block but stopping short to avoid the bomb,  making it impossible to get full points. This pattern is highly discouraged. <details><summary>**Example Image**</summary>![Picture of hammer hit](~@images/mapping/hammer-hit-alt.png)</details> |
+| **Handclap** | Any [Pattern](#p) that directs the player's hands inward at each other on the same beat, often leading to the player smashing their hands together. Higher skilled players can sometimes avoid these, but they are still highly discouraged at all levels of mapping. Also known as [Controller Clash/Smash](#c).  <details><summary>**Example Image**</summary>![Picture of handclap](~@images/mapping/controller-smash-alt.png)</details> |
+| **Hitbox** | The region where the saber collides with an object. [Note](#n) hitboxes are larger than they visually appear, [Bomb](#b) hitboxes are smaller than they visually appear, and [Wall](#wxyz) hitboxes are exactly the size that they visually appear. |
+| **Hitbox Abuse** | [Notes](#n) placed in the pre- or post-swing path of an opposite color note. <details><summary>**Example Image**</summary>![Picture of hitbox abuse](~@images/mapping/hitbox-abuse-alt.png)</details> |
+| **Hook** | A [Pattern](#p) of two sequential up/down [Blocks](#b) of the same color with usually one [Lane](#l) in between. The player's arm makes a hook motion to play this pattern. <details><summary>**Example Image**</summary>![Picture of hook](~@images/mapping/hook.png)</details> |
+| **Hot Start** | When the first [Notes](#n) of a map appear within two seconds of the beginning of the song. |
+| **Hyper Wall** | A [Wall](#wxyz) with a negative duration value lower than the map's [Half Jump Duration](#h) that appears to move past the player at an even faster speed than [Fast Walls](#f). |
 
 ## I
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Info File** | The primary map file that includes information and metadata for all difficulties of a map. In 2.0 song format this file is a .dat file. In 1.0 song format this was a .json file. See also Difficulty File |
-| **Inline** | Patterns that remain in one column/lane and row/layer for 2 or more blocks in a row. Typically refers to two alternating colors, but not always. <details><summary>**Example Image**</summary>![Picture of inline](~@images/mapping/inline.png)</details>|
-| **Inner Ring** | A small ring around the track found in some in-game environments. |
-| **Invert** | Blocks pointing inwards from the outside requiring a larger pre swing to hit. <details><summary>**Example Image**</summary>![Picture of invert](~@images/mapping/invert.png)</details>|
+| **Info File** | The primary map file that includes information and metadata for all difficulties of a map. In 2.0 song format, this file is a [.dat File](#d). In 1.0 song format, this was a [.json File](#j). See also [Difficulty File](#d). |
+| **Inline** | A [Pattern](#p) that remains in one [Column](#c) and [Row](#r) for two or more blocks in a row. This typically refers to two alternating colors, but not always. <details><summary>**Example Image**</summary>![Picture of inline](~@images/mapping/inline.png)</details> |
+| **Inner Ring** | A small ring around the [Track](#t) found in some in-game [Environments](#e). |
+| **Invert** | [Blocks](#b) pointing inwards from the outside requiring a larger pre-swing to hit. <details><summary>**Example Image**</summary>![Picture of invert](~@images/mapping/invert.png)</details> |
 
 ## JK
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **.json File** | The text file containing most content for that difficulty or song info in the old 1.0 song format. Contains same format but different structure to .dat files, with a different file extension. File format is used for both song info and for map content. See also [Info File](#i), [Difficulty File](#d) |
-| **JSON Wall** | A style of mapping requiring Mapping Extensions in which the mapper can be extremely creative with non-standard wall types and sizes. Not recommended for novice mappers. |
-| **Jump** | A pattern that moves across multiple lanes/columns (horizontally) or layers/rows (vertically) in rapid succession. Not recommended below 1/2 precision, especially at high tempo. The faster the jumps are, the more difficult they are to execute. See also [Jump Stream](#jk) <details><summary>**Example Image**</summary>![Picture of jump](~@images/mapping/jump.jpg)</details>|
-| **Jump Stream** | A style of mapping that includes jumps within a stream. <details><summary>**Example Image**</summary>![Picture of jump stream](~@images/mapping/jumpstream.jpg)</details>|
+| **.json File** | The text file containing most content for a certain difficulty or song info in the old 1.0 song format. It contains JSON format with a different structure to [.dat Files](#d), and a different file extension. This file format is used for both song info and for map content. See also: [Info File](#i), [Difficulty File](#d). |
+| **JSON Wall** | A style of mapping requiring the mod [Mapping Extensions](#m), in which the mapper can be extremely creative with non-standard [Wall](#wxyz) types and sizes. Not recommended for novice mappers. |
+| **Jump** | A [Pattern](#p) that moves across multiple [Columns](#l) horizontally or [Rows](#r) vertically in rapid succession. This pattern is not recommended below 1/2 [Precision](#p), especially at high [Tempos](#t). The faster the jumps are, the more difficult they are to execute. See also: [Jump Stream](#jk). <details><summary>**Example Image**</summary>![Picture of jump](~@images/mapping/jump.jpg)</details> |
+| **Jump Stream** | A [Pattern](#p) that includes [Jumps](#jk) within a [Stream](#s). <details><summary>**Example Image**</summary>![Picture of jump stream](~@images/mapping/jumpstream.jpg)</details> |
 
 ## L
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Lane** | Horizontal divisions across the track down which blocks travel. The default track has four lanes. Also known as [Column](#c). See also: [Row](#r), [Layer](#l) |
-| **Layer** | Vertical divisions above the track, down which blocks travel. The default track has three layers (bottom, middle, top). Also known as [Row](#r). See also: [Lane](#l), [Column](#c) |
-| **Lawless Mode** | A map characteristic where mappers can do crazy stuff they would get downvoted into oblivion for in a standard cha. Not part of the base game and requires the SongCore mod. |
-| **Lefty Stream** | A straight [Stream](#s) where each pair of successive notes going in the same direction starts with the left hand. Related: [Righty Stream](#r) <details><summary>**Example Image**</summary>![Picture of lefty stream](~@images/mapping/lefty-stream.jpg)</details>|
-| **Lighting** | A collective term for all of the lighting events and options available to mappers. A map is not considered complete without some form of lighting. See also [Event](#e) |
-| **Lighting Track** | The area in most map editors where lighting events are placed. See also [Track](#t) |
-| **Lightshow Mode** | A map characteristic where there are no blocks, only lighting. Not part of the base game and requires the SongCore mod. |
-| **Loloppe Notes** | Two same direction blocks placed side-by-side such that hitting both requires abusing the block hitbox. Named after the mapper who made them famous. <details><summary>**Example Image**</summary>![Picture of loloppe notes](~@images/mapping/loloppe.png)</details>|
+| **Lane** | Horizontal divisions across the [Track](#t) in which [Blocks](#b) travel. The default track has four lanes. Also known as [Column](#c). See also: [Row](#r), [Layer](#l). |
+| **Layer** | Vertical divisions above the [Track](#t) in which [Blocks](#b) travel. The default track has three layers, commonly referred to as bottom, middle, and top. Also known as [Row](#r). See also: [Lane](#l), [Column](#c). |
+| **Lawless Mode** | A map characteristic where mappers can do crazy stuff that they would normally get downvoted into oblivion for in a standard map. This mode is not part of the base game and requires the [SongCore](#s) mod. |
+| **Lefty Stream** | A straight [Stream](#s) where each pair of successive [Notes](#n) going in the same direction starts with the left hand. See also: [Righty Stream](#r). <details><summary>**Example Image**</summary>![Picture of lefty stream](~@images/mapping/lefty-stream.jpg)</details> |
+| **Lighting** | A collective term for all of the lighting events and options available to mappers. A map is not considered complete without some form of lighting. See also: [Event](#e). |
+| **Lighting Track** | The area in most map editors where [Lighting](#l) events are placed. See also: [Track](#t). |
+| **Lightshow Mode** | A map characteristic where there are no [Blocks](#b), only [Lighting](#l). This mode is not part of the base game and requires the [SongCore](#s) mod. |
+| **Loloppe Notes** | Two same direction [Blocks](#b) placed side-by-side such that hitting both blocks requires abusing the block [Hitbox](#h). Named after the mapper who made them famous. <details><summary>**Example Image**</summary>![Picture of loloppe notes](~@images/mapping/loloppe.png)</details> |
 
 ## M
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Map Blindness** | Mapper blindness arises when a mapper has spent so much time on a map. You know the patterns, you know your intentions. You've self tested it so many times. Eventually, muscle memory and subconscious kicks in, and you can play the map with your eyes closed, regardless of flaws. |
-| **Mapping Extensions** | A mod developed by Kyle1314 that allows mappers access to a number of unique utilities for advanced mapping. See also [Precision Placement](#p), [Precision Rotation](#p), [JSON Walls](#jk) |
-| **Mediocre Map Assistant 2** | A new fork of Mediocre Mapper by Assistant. The primary map editor used by the mapping community. |
-| **Mediocre Mapper** | An outdated editor, developed by squeaksies as a fork of the original EditSaber editor by Ikiewa. No longer in public development or supported by its author it has been forked to created **Mediocre Map Assistant 2**. |
-| **Mine** | A *block* that looks like a spiky circle and that damages the player if their saber touches it. It is safe for a mine to pass through the player’s body. Also known as [Bomb](#b) |
+| **Map Blindness** | A condition that may occur when a mapper has spent so much time on a map. You know the patterns, you know your intentions. You've self-tested it so many times. Eventually, muscle memory and your subconscious kick in, and you can play the map with your eyes closed, regardless of flaws. See also: [Testplay](#t). |
+| **Mapping Extensions** | A mod developed by Kyle1314 that allows mappers to access a number of unique utilities for advanced mapping. See also: [Precision Placement](#p), [Precision Rotation](#p), [JSON Walls](#jk). |
+| **Mediocre Map Assistant 2** | A new fork of [Mediocre Mapper](#m) by Assistant. This is the primary map editor used by the mapping community. |
+| **Mediocre Mapper** | An outdated editor, developed by squeaksies as a fork of the original EditSaber editor by Ikiewa. No longer in public development or supported by its author, it has been forked to created [Mediocre Map Assistant 2](#m). |
+| **Mine** | A [Block](#b) that looks like a spiky circle that damages the player if their saber touches it. It is safe for a bomb to pass through the player’s body. Also known as [Bomb](#b). |
 | **Mismap** | A mistake, incorrect, or faulty choice in a map. |
-| **Modding** | Modding is a term borrowed from osu!. It is the process of reviewing and providing feedback for a map (for rankability or just general improvement) via editor and in-game analysis. Unrelated to game mods that alter the UI or gameplay of Beat Saber. See this [guide](https://bit.ly/ScoreSaberModding) to get started with modding. |
-| **Multiple BPM** | A song with one or more BPM changes as intended by the song’s composer. Also known as [Variable BPM](#uv) and [Drifting BPM](#d). See also [Fixed BPM](#f) |
+| **Modding** | Modding is a term borrowed from [osu!](#o). It is the process of reviewing and providing feedback for a map via editor and in-game analysis for rankability and/or general improvements. This term is unrelated to game mods that alter the UI or gameplay of Beat Saber. See this [guide](https://bit.ly/ScoreSaberModding) to get started with modding. See also: [Playtest](#p). |
+| **Multiple BPM** | A song with one or more [BPM](#b) changes as intended by the song’s composer. Also known as [Variable BPM](#uv) and [Drifting BPM](#d). See also: [Fixed BPM](#f). |
 
 ## N
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **NJS** | Abbreviation of Note Jump Speed. |
-| **NPS** | Abbreviation of Notes Per Second. |
-| **No Arrows Mode** | A map characteristic using only dot notes. Often used by new players or for alternate play styles like "maul mode." |
+| **NJS** | Abbreviation of [Note Jump Speed](#n). |
+| **NPS** | Abbreviation of [Notes Per Second](#n). |
+| **No Arrows Mode** | A map characteristic using only [Dot Notes](#d). Often used by new players or for alternate play styles like "maul mode." |
 | **Noodle Extensions** | A more advanced version of [Mapping Extensions](#m) that is only available on PC. |
-| **Note** | A cube with either an arrow or dot on it. The primary element of gameplay. By default, notes are red or blue. Also known as [Block](#b) |
-| **Note Jump Speed** | The speed that objects approach the player in-game. Labeled in Info.dat as "noteJumpMovementSpeed". Abbreviated NJS |
-| **Notes Per Second** | A measure of map density. The number of notes that pass the player within one second. A very rough approximate measure of difficulty. Abbreviated NPS |
+| **Note** | A cube with either an arrow or a dot on it. It is the primary element of gameplay. By default, blocks are either red or blue. Also known as [Block](#b). |
+| **Note Jump Speed** | The speed that objects approach the player in-game. Labeled in Info.dat as `_noteJumpMovementSpeed`. Abbreviated [NJS](#n). |
+| **Notes Per Second** | A measure of map density. The number of [Notes](#n) that pass the player within one second. A very rough approximate measure of difficulty. Abbreviated [NPS](#n). |
 
 ## O
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Obstacle** | A generic term for both walls (all types) and bombs. See also: [Wall](#wxyz), [Fake Wall](#f) |
-| **Offset** | A value in milliseconds (ms) used in the map editor to perfectly align the track beat markers with the beat of the music. Song files set up correctly with the BPM aligned in an audio editor do not usually need an offset value. |
-| **.ogg File** | The [OGG Vorbis](https://en.wikipedia.org/wiki/Vorbis) audio file format |
-| **One Handed Jumps** | Abbreviated OHJ, a sequence of [Jumps](#jk) using only one color. |
-| **OneSaber Mode** | A map characteristic using only one saber. The second saber disappears completely when playing. |
+| **Obstacle** | A generic term for both all types of [Walls](#wxyz) and [Bombs](#b). See also: [Wall](#wxyz), [Fake Wall](#f), [Bomb](#b). |
+| **Offset** | A value in milliseconds (ms) used in the map editor to perfectly align the track beat markers with the beat of the music. Song files set up correctly with the [BPM](#b) aligned in an audio editor do not usually need an offset value. |
+| **.ogg File** | The [OGG Vorbis](https://en.wikipedia.org/wiki/Vorbis) audio file format. |
+| **OHJ** | Abbreviation of [One Handed Jump](#o). |
+| **One Handed Jump** | A sequence of [Jumps](#jk) using only one color. Abbreviated as [OHJ](#o). |
+| **OneSaber Mode** | A map characteristic using only one saber. The left-handed saber disappears completely when playing, unless the player has enabled the Left-Handed option in-game. |
 | **osu!** | Another popular rhythm game with a large library of custom maps. Converters exist to translate timings from *osu!* maps into Beat Saber maps. |
-| **Overmapping** | Using multiple notes with different time values to represent a single sound. This doesn't apply to the extra notes in sliders. |
+| **Overmapping** | Using multiple [Notes](#n) with different time values to represent a single sound. This does not apply to the extra notes in [Sliders](#s). |
 
 ## P
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Parity** | The mathematical term describing the ‘group’ a block belongs to- within the context of Beat Saber, this refers to the forehand/backhand nature of a block. |
-| **Pattern** | A generic name for a sequence of blocks. |
-| **Paul** | A sequence of inline blocks of the same direction placed at very high precision. This forces the player to hit with a slow continuous swing. This pattern is impossible to score well on. <details><summary>**Example Image**</summary>![Picture of paul](~@images/mapping/paul.jpg)</details>|
-| **Piano Stream** | A sequence of alternating color and direction blocks that progresses horizontally across lanes on the track. <details><summary>**Example Image**</summary>![Picture of piano stream](~@images/mapping/pianostream.png)</details>|
-| **Playtest** | The act of playing a WIP map to check for errors and improvements. Highly recommended for a quality product. |
-| **Performance Points** | The metric determining ranking on the ScoreSaber leaderboards. Abbreviated PP. |
-| **Platform** | The in-game play area and associated track and lights. Also known as [Environment](#e) |
-| **PP** | Abbreviation of Performance Points. |
-| **Precision** | The division of a beat in an editor; used to place notes consistently. Typically 1/1 (one note per beat), 1/2 (one note per half beat), or 1/4 (one note per quarter beat). Also known as [Cursor Precision](#c) |
-| **Precision Placement** | A style of mapping that requires Mapping Extensions which allows the mapper to place blocks outside of the standard 4 x 3 grid. Not recommended for novice mappers. |
-| **Precision Rotation** | A style of mapping that requires Mapping Extensions which allows the mapper to freely rotate blocks (vs. the standard 45 degree rotation). Not recommended for novice mappers. |
+| **Parity** | The mathematical term describing the ‘group’ a [Block](#b) belongs to. Within the context of Beat Saber, this refers to the [Forehand](#f) and [Backhand](#b) nature of a block. |
+| **Pattern** | A generic name for a sequence of [Blocks](#b). |
+| **Paul** | A sequence of inline [Blocks](#b) of the same direction placed at very high [Precision](#p). This forces the player to hit the sequence with a slow continuous swing. This [Pattern](#p) is very difficult to score well on. <details><summary>**Example Image**</summary>![Picture of paul](~@images/mapping/paul.jpg)</details> |
+| **Piano Stream** | A sequence of alternating color and direction [Blocks](#b) that progresses horizontally across [Lanes](#l) on the [Track](#t). <details><summary>**Example Image**</summary>![Picture of piano stream](~@images/mapping/pianostream.png)</details> |
+| **Playtest** | The act of playing a WIP map to check for errors and improvements. Highly recommended for a quality product. Also known as [Testplay](#t). |
+| **Performance Points** | The metric determining ranking on the [ScoreSaber](#s) leaderboards. Abbreviated as [PP](#p). |
+| **Platform** | The in-game play area, and associated [Track](#t) and [Lighting](#l). Also known as [Environment](#e). |
+| **PP** | Abbreviation of [Performance Points](#p). |
+| **Precision** | The musical duration of the spacing between [Notes](#n). Typically 1/1 (one note per beat), 1/2 (one note per half beat), or 1/4 (one note per quarter beat). Also known as [Cursor Precision](#c). |
+| **Precision Placement** | A style of mapping that requires [Mapping Extensions](#m), which allows the mapper to place [Blocks](#b) outside of the standard 4x3 grid. Not recommended for novice mappers. |
+| **Precision Rotation** | A style of mapping that requires [Mapping Extensions](#m), which allows the mapper to freely rotate [Blocks](#b) (compared to the standard 45 degree rotations). Not recommended for novice mappers. |
 
 ## Q
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Quads** | A horizontal pattern of four horizontal blocks of the same color across the track. Almost impossible to score well on the entire hit and highly discouraged. This pattern can easily be replaced with a slider. <details><summary>**Example Image**</summary>![Picture of quad](~@images/mapping/quad.jpg)</details>|
+| **Quad** | A horizontal [Pattern](#p) of four horizontal [Blocks](#b) of the same color across the [Track](#t). This pattern is very difficult to score well on the entire hit, and is highly discouraged. This pattern can easily be replaced with a [Slider](#s). <details><summary>**Example Image**</summary>![Picture of a quad](~@images/mapping/quad.jpg)</details> |
 
 ## R
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Ranked** | Indicating that the map has been Modded and approved by the ScoreSaber ranking team as of a quality appropriate of contributing to the PP leaderboard. Maps should be modded prior to submitting a rank request. |
-| **Release** | The act of publishing a finished map on BeatSaver. Once a map is released it can be downloaded and played by anyone. Do not release unfinished or untested maps |
-| **Reset** | The action of bringing your arms back to their "ready" position, as if no blocks have been hit recently. Mappers can also attempt to reset the player by using bombs to force arm movement. See also [Bomb Reset](#b) |
-| **RGB** | A style of lighting that requires Chroma and allows lighting events to be any color and often uses more than two colors. |
-| **Right Triangle** | Variation of a [Triangle](#t) where there is a 90 degree hit in the sequence causing major comfort issues at lower precision. <details><summary>**Example Image**</summary>![Picture of right traingle](~@images/mapping/right-triangle.jpg)</details>|
-| **Righty Stream** | A straight [Stream](#s) where each pair of successive notes going in the same direction starts with the right hand. Related: [Lefty Stream](#l) <details><summary>**Example Image**</summary>![Picture of righty stream](~@images/mapping/righty-stream.jpg)</details> |
-| **Row** | Vertical divisions above the track, down which blocks travel. The default track has three rows (bottom, middle, top). Also known as [Layer](#l). See also: [Lane](#l), [Column](#c) |
+| **Ranked** | A map that has been [Modded](#m) and approved by the [ScoreSaber](#s) ranking team as having a quality appropriate of contributing to the [PP](#p) leaderboard. Maps should be modded prior to submitting a rank request. |
+| **Release** | The act of publishing a finished map on [BeatSaver](#b). Once a map is released, it can be downloaded and played by anyone. Do not release unfinished or untested maps. |
+| **Reset** | The action of bringing your arms back to their "ready" position, as if no [Blocks](#b) have been hit recently. Mappers can also attempt to reset the player by using [Bombs](#b) to force arm movement. See also: [Bomb Reset](#b). |
+| **RGB** | A style of [Lighting](#l) that requires the [Chroma](#c) mod and allows lighting events to be of any color and to use more than two colors. |
+| **Right Triangle** | A variation of a [Triangle](#t) where there is a 90 degree hit in the sequence causing major comfort issues at lower [Precision](#p). <details><summary>**Example Image**</summary>![Picture of right triangle](~@images/mapping/right-triangle.jpg)</details> |
+| **Righty Stream** | A straight [Stream](#s) where each pair of successive [Notes](#n) going in the same direction starts with the right hand. See also: [Lefty Stream](#l). <details><summary>**Example Image**</summary>![Picture of righty stream](~@images/mapping/righty-stream.jpg)</details> |
+| **Row** | Vertical divisions above the [Track](#t) in which [Blocks](#b) travel. The default track has three layers, commonly referred to as bottom, middle, and top. Also known as [Layer](#l). See also: [Lane](#l), [Column](#c). |
 
 ## S
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **ScoreSaber** | The organization responsible for managing the ranked Beat Saber leaderboards. |
-| **Scissor** | Otherwise known as a *Cucumber*, is when a red and blue note are on the same timing, and are hit simultaneously in opposite directions. Related: [Crossover Scissor](#c) <details><summary>**Example Image**</summary>![Picture of scissor](~@images/mapping/scissor-cucumber_example.png)</details> |
-| **Scoop** | A pattern of blocks where the player makes a "scooping" motion to play the pattern. Typically a left or right note followed by an up note, in the bottom row.  Give the player ample time to react when using scoops, a half to full beat is recommended. <details><summary>**Example Image**</summary>![Picture of scoop](~@images/mapping/scoop_example.png)</details> |
-| **Setup** | The process of maneuvering the players arms into position for a pattern via appropriate placement of the preceding blocks. |
-| **Single** | A single block hit with one saber. Typically makes up the majority of patterns in a map. See also [Double](#d) |
-| **Single BPM** | A song with a consistent BPM from start to finish with no variation. Also known as [Fixed BPM](#f). See also [Variable BPM](#uv) |
-| **Sliders** | A series of same-colored dots or arrow blocks spaced close enough together for the player to sweep the saber through in one motion. Placed at 1/12 or higher precision. <details><summary>**Example Image**</summary>![Picture of sliders](~@images/mapping/sliders.png)</details>|
-| **Spawn Distance** | The distance down the track where the blocks and obstacles spawn. Measured in beats; therefore varies in "spatial" distance by BPM . See also [Spawn Point](#s), [NJS](#n), [BPM](#b), and [Spawn Offset](#s). Also known as [Half Jump Duration](#h). |
-| **Spawn Offset** | A variable denoted as `_noteJumpStartBeatOffset` in the map's Info File that modifies the spawn distance. Can be a floating value, typically between -1.0 and 1.0. Also known as [Spawn Distance Modifier](#s) |
-| **Spawn Point** | The location on the track where blocks and obstacles first appear, accompanied by a flash of light. See also [Spawn Distance](#s) |
-| **Spiral** | A slider whose path traces a rotation long enough to return to its original direction or further. See also [Bomb Spiral](#b) <details><summary>**Example Image**</summary>![Picture of spiral](~@images/mapping/spiral.jpg)</details>|
-| **Stack** | Two same-colored, same-direction blocks placed in a line on the same beat. Results in the player swinging a larger, faster hit. Related: [Tower](#t) <details><summary>**Example Image**</summary>![Picture of stack](~@images/mapping/stacks.jpg)</details>|
-| **Staggers** | Sliders placed with spacing too large for the player to hit in one motion, considered a mismap. Occurs when sliders are placed lower than 1/8 precision. <details><summary>**Example Image**</summary>![Picture of stagger](~@images/mapping/stagger.jpg)</details>|
-| **Staircase** | A pattern where a block's direction points towards the following block. Does not include blocks on the same beat. Can be a potential hitbox issue where a block is placed in the postswing of a previous block. <details><summary>**Example Image**</summary>![Picture of staircase](~@images/mapping/staircase.jpg)</details>|
-| **Stream** | A steady, sustained pattern of notes, typically at 1/4 precision. <details><summary>**Example Image**</summary>![Picture of stream](~@images/mapping/stream.png)</details>|
-| **Strobe** | 1) n. A rapidly flashing on/off light <br> 2) v. To cause a light to flash on/off or on/flash when lighting a map. |
-| **Swings per second** | A variation on [Notes per second](#n) that isn't inflated by stacks of sliders. Can give a better representation of a map's difficulty. |
+| **ScoreSaber** | The organization responsible for managing the ranked Beat Saber leaderboards. The Beat Saber leaderboards website can be found [here](https://scoresaber.com/). |
+| **Scissor** | When a red and blue [Note](#n) are on the same timing, and are hit simultaneously in opposite directions. Also known as [Cucumber](#c). See also: [Crossover Scissor](#c). <details><summary>**Example Image**</summary>![Picture of scissor](~@images/mapping/scissor-cucumber_example.png)</details> |
+| **Scoop** | A [Pattern](#p) of [Blocks](#b) where the player makes a "scooping" motion to play the pattern. Typically a left or right note followed by an up note in the bottom row. Give the player an ample amount of time to react when using scoops - a half to full beat is recommended. <details><summary>**Example Image**</summary>![Picture of scoop](~@images/mapping/scoop_example.png)</details> |
+| **Setup** | The process of maneuvering the player's arms into position for a [Pattern](#p) via appropriate placement of the preceding [Blocks](#b). |
+| **Single** | A single [Block](#b) hit with one saber. Typically makes up the majority of [Patterns](#p) in a map. See also: [Double](#d). |
+| **Single BPM** | A song with a consistent [BPM](#b) from start to finish with no variation. Also known as [Fixed BPM](#f). See also [Variable BPM](#uv). |
+| **Sliders** | A series of same-colored [Dot Notes](#d) or [Arrow Blocks](#a) spaced close enough together for the player to sweep the saber through in one motion. Placed at a [Precision](#p) of 1/12 or faster. <details><summary>**Example Image**</summary>![Picture of sliders](~@images/mapping/sliders.png)</details> |
+| **Spawn Distance** | The distance down the [Track](#t) where the [Blocks](#b) and [Obstacles](#o) spawn. Measured in beats, therefore varies in "spatial" distance by [BPM](#b). Also known as [Half Jump Duration](#h). See also: [Spawn Point](#s), [NJS](#n), [BPM](#b), [Spawn Offset](#s). |
+| **Spawn Distance Modifier** | A variable denoted as `_noteJumpStartBeatOffset` in the map's [Info File](#i) that modifies the [Spawn Distance](#d). Can be a floating value, typically between -1.0 and 1.0. Also known as [Spawn Offset](#s).
+| **Spawn Offset** | A variable denoted as `_noteJumpStartBeatOffset` in the map's [Info File](#i) that modifies the [Spawn Distance](#d). Can be a floating value, typically between -1.0 and 1.0. Also known as [Spawn Distance Modifier](#s). |
+| **Spawn Point** | The location on the [Track] where [Blocks] and [Obstacles] first appear, accompanied by a flash of light. See also: [Spawn Distance](#s). |
+| **Spiral** | A [Slider](#s) whose path traces a rotation long enough to return to its original direction or further. See also: [Bomb Spiral](#b). <details><summary>**Example Image**</summary>![Picture of spiral](~@images/mapping/spiral.jpg)</details> |
+| **Stack** | Two same-colored, same-direction [Blocks] placed in a line on the same beat. Results in the player swinging a larger, faster hit. See also: [Tower](#t). <details><summary>**Example Image**</summary>![Picture of stack](~@images/mapping/stacks.jpg)</details> |
+| **Stagger** | A [Slider](#s) placed with the spacing between [Blocks](#b) too large for the player to hit in one motion. This is considered a [Mismap](#m). Occurs when sliders are placed slower than 1/8 [Precision](#p). <details><summary>**Example Image**</summary>![Picture of stagger](~@images/mapping/stagger.jpg)</details> |
+| **Staircase** | A [Pattern] where a [Block](#s)'s direction points towards the following block. This does not include blocks on the same beat. Can be a potential [Hitbox](#h) issue where a block is placed in the post-swing of a previous block. <details><summary>**Example Image**</summary>![Picture of staircase](~@images/mapping/staircase.jpg)</details> |
+| **Stream** | A steady, sustained [Pattern](#p) of [Notes](#n), typically at 1/4 [Precision](#p). <details><summary>**Example Image**</summary>![Picture of stream](~@images/mapping/stream.png)</details> |
+| **Strobe** | 1) *noun*. A rapidly flashing on/off light. <br> 2) *verb*. To cause a light to flash on/off or flicker when [Lighting](#l) a map. |
+| **Swings Per Second** | A variation on [Notes per second](#n) that is not inflated by lots of [Sliders](#s). This metric can give a better representation of a map's difficulty. |
 
 ## T
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Tangle** | A pattern that results in arm paths preventing the next motion from occurring without resetting. Occurs commonly in incorrect crossovers. |
-| **Tempo** | A musical term for the speed of music. Can change throughout the duration of a song. |
-| **Thin Wall** | A wall that is only a tiny fraction of a beat thick that sometimes doesn't tick for any damage on the player. Created in Mediocre Map Assistant 2 by clicking to add a wall then immediately clicking to "drop" it, without scrolling for any time duration. See also [Wall](#wxyz), [Fake Wall](#f) <details><summary>**Example Image**</summary>![Picture of thin wall](~@images/mapping/thinwall.png)</details> |
-| **Tower** | Three same-colored, same-direction blocks placed in a line on the same beat. Results in the player swinging a larger, faster hit. Related: [Stack](#s) <details><summary>**Example Image**</summary>![Picture of tower](~@images/mapping/tower.jpg)</details>|
-| **Track** | The area in an editor where blocks are placed and the are in-game where blocks spawn and move toward the player. In most editors there is a track for notes/blocks and a separate track for lighting. See also [Lighting Track](#l) |
-| **Triangle** | Three or more notes forming a "triangle" pattern with position and orientation. Causes a Wrist Reset, especially if used in high precision (under 1/1). <details><summary>**Example Image**</summary>![Picture of triangle](~@images/mapping/triangle.png)</details>|
+| **Tangle** | A [Pattern](#p) that results in arm paths preventing the next motion from occurring without [Resetting](#r). This occurs commonly in incorrect [Crossovers](#c). |
+| **Tempo** | A musical term for the speed of music. The tempo can change throughout the duration of a song. |
+| **Thin Wall** | A [Wall](#wxyz) that is only a tiny fraction of a beat long that sometimes does not cause any damage to the player. Created in [Mediocre Map Assistant 2](#m) by clicking to add a wall then immediately clicking to "drop" it, without scrolling for any time duration. See also: [Wall](#wxyz), [Fake Wall](#f). <details><summary>**Example Image**</summary>![Picture of thin wall](~@images/mapping/thinwall.png)</details> |
+| **Tower** | Three same-colored, same-direction [Blocks] placed in a line on the same beat. Results in the player swinging a larger, faster hit. See also: [Stack](#s). <details><summary>**Example Image**</summary>![Picture of tower](~@images/mapping/tower.jpg)</details>|
+| **Track** | The area in an editor where [Blocks](#b) are placed and the area in-game where blocks spawn and move towards the player. In most editors, there is a track for notes/blocks and a separate track for [Lighting](#l). See also: [Lighting Track](#l). |
+| **Triangle** | Three or more [Notes](#n) forming a "triangle" pattern with position and orientation, causing a [Wrist Reset](#wxyz), especially if used in high [Precision](#p) (under 1/1). <details><summary>**Example Image**</summary>![Picture of triangle](~@images/mapping/triangle.png)</details> |
 
 ## UV
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Variable BPM** | 1) A song with an intentionally shifting BPM as intended by its composer 2) A song with irregular, unintentionally shifting BPM as a result of fluctuations; for example, a live performance without a metronome. (from Ranking Criteria) Also known as [Drifting BPM](#d) and [Multiple BPM](#m). See also [Fixed BPM](#f) |
-| **Vibro** | An extremely high speed stream of a pace requiring small wrist motions to hit, typically 1/8. Note that this does NOT apply to dots. Also known as *Vibro Stream* <details><summary>**Example Image**</summary>![Picture of vibro](~@images/mapping/vibro.jpg)</details>|
-| **Vision Block** | A sequence of blocks, typically using the middle row, that blocks the player’s vision of the following notes. The most common form of vision blocks are Face Notes but blocks outside of the center two squares can also block line of sight to later blocks. Abbreviated *VB*. <details><summary>**Example Image**</summary>![Picture of vision block](~@images/mapping/vb_example.png)</details>|
+| **Variable BPM** | 1) A song with an intentionally shifting [BPM](#b) as intended by its composer. <br> 2) A song with irregular, unintentionally shifting BPM as a result of fluctuations; for example, a live performance without a metronome (definition provided by [ScoreSaber](#s)'s Ranking Criteria). <br> Also known as [Drifting BPM](#d) and [Multiple BPM](#m). See also: [Fixed BPM](#f). |
+| **VB** | Abbeviation of [Vision Block](#uv). |
+| **Vibro** | An extremely high speed [Stream](#s) of a pace requiring small wrist motions to hit, typically at 1/8 [Precision](#p). Note that this does NOT apply to [Dot Notes](#d). Also known as [Vibro Stream](#uv). <details><summary>**Example Image**</summary>![Picture of vibro](~@images/mapping/vibro.jpg)</details> |
+| **Vibro Stream** | An extremely high speed [Stream](#s) of a pace requiring small wrist motions to hit, typically at 1/8 [Precision](#p). Note that this does NOT apply to [Dot Notes](#d). Also known as [Vibro](#uv). <details><summary>**Example Image**</summary>![Picture of vibro](~@images/mapping/vibro.jpg)</details> |
+| **Vision Block** | A sequence of [Blocks](#b), typically using the middle [Row](#r), that blocks the player’s vision of the following notes. The most common form of vision blocks are [Face Notes](#f), but blocks outside of the center two squares can also block line of sight to later blocks. Abbreviated as [VB](#uv). <details><summary>**Example Image**</summary>![Picture of vision block](~@images/mapping/vb_example.png)</details> |
 
 ## WXYZ
 | Term&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Definition |
 | - | :- |
-| **Wall** | A translucent barrier that damages the player if they put their body in it. It is safe for players to rest their sabers in walls. Also known as Obstacle. See also: [Fake Walls](#f) <details><summary>**Example Image**</summary>![Picture of wall](~@images/mapping/wall.png)</details>|
-| **Window** | A 3-block or larger tower containing a gap allowing for vision through the tower. <details><summary>**Example Image**</summary>![Picture of window](~@images/mapping/window.jpg)</details>|
-| **Window Slider** | A 3-long [Slider](#s) with the center note removed to allow for better vision. |
-| **WIP** | Work-In-Progress; not yet finished. WIP maps must be played in either party mode or practice mode until released to prevent stray ScoreSaber leaderboards from being created for each revision. |
-| **Wrist Reset** | The action of resetting only your wrist due to a sequence of notes that requires a large twist of the wrist. |
+| **Wall** | A translucent barrier that damages the player if they put their head in it. It is safe for players to rest their sabers in walls. See also: [Obstacle](#o), [Fake Walls](#f). <details><summary>**Example Image**</summary>![Picture of wall](~@images/mapping/wall.png)</details> |
+| **Window** | A 3-block or larger [Tower](#t) containing a gap allowing for vision through the tower. <details><summary>**Example Image**</summary>![Picture of window](~@images/mapping/window.jpg)</details> |
+| **Window Slider** | A 3-long [Slider](#s) with the center [Note](#n) removed to allow for better vision. |
+| **WIP** | Abbreviation of "Work-In-Progress", meaning not yet finished. WIP maps must be played in either party mode or practice mode until released to prevent stray [ScoreSaber](#s) leaderboards from being created for each revision. |
+| **Wrist Reset** | The action of [Resetting](#r) only your wrist due to a sequence of [Notes](#n) that require a large twist of the wrist. |


### PR DESCRIPTION
I noticed that the Mapping Glossary has evolved over time, and the inconsistency between glossary entries has been growing.

I went through every glossary entry ensuring that they followed as-closely-as-possible the standard that I will outline below. By no means is the standard set in stone, so please feel free to challenge any of the standards written or changes that I have made. The overall goal in my perspective is to have a consistent guideline for new terms so we do not run into a situation where the way of writing terms and definitions changes again.

I also corrected any typos or questionable grammar that I encountered, as well as added a few terms that were referenced in the definitions that did not have an entry within the glossary already. I did not change the meaning of any of the definitions other than adding clarifications or expanding upon the meaning. If any of my changes have modified the meaning of the glossary entry incorrectly, please let me know so I can get that fixed or reverted.

Some of these changes would definitely fit better in a glossary that is able to jump directly to individual terms rather than to individual letters, but this sets us up in a good position later down the line if we ever implement the ability to do so.

**Standard:**
- Every term is in the singular form, unless plural by official name (e.g. Mapping Extensions).
- Every term has the first letter of each word capitalized.
- Terms that vary only slightly (e.g Arrow Block and Arrow Note -> Arrow Block/Note, or Vibro and Vibro Stream -> Vibro Stream) are combined into one entry and are both noted in a "Referred to as [...]" note in the definition.
- Abbreviations have been removed from the term itself (e.g. Double Directional (DD) -> Double Directional), and has an entry added pointing to the original term.
- Terms have been alphabetized.
- Definitions all follow the same general format of [Definition] [Referred ... / Abbreviated ... / Also known as ...] [URL link] [See also: ...] [Example Image].
- If another glossary term is used within a definition, the first occurrence of the word will have its first letter capitalized and point to its definition. Subsequent uses of the word are lower-case and do not point to the definition.
- Any "Also known as ..." terms that were significantly different than the original have been added as new terms (e.g. Crossover Scissor and Pickle).
- List of "See also: ..." terms have been alphabetized.
- List of "See also: ..." terms have been cleaned to be less redundant if the term has already been used and linked within the definition.

**Notable Term Changes:** _(note: does not include small changes such as singular form or capitalization)_
- Added BeastSaber
- Added ChroMapper
- Added DD
- Added Flick
- Added OHJ
- Added Pickle
- Added SongCore
- Added Spawn Distance Modifier
- Added Testplay
- Added VB
- Changed Arrow Block -> Arrow Block/Note
- Changed Double Directionals (DD) -> Double Directional
- Changed Vibro -> Vibro Stream


Please let me know if there are any questions/comments/concerns, I'd be happy to answer in any way I can!