### PR TITLE
Change BSIPA link to point to the BSIPA docs

### DIFF
--- a/wiki/modding/README.md
+++ b/wiki/modding/README.md
@@ -39,4 +39,4 @@ Helpful launch arguments that will make modding / debugging easier.
 * [Unity Scripting API](https://docs.unity3d.com/ScriptReference/index.html)
 * [dnSpy](https://github.com/0xd4d/dnSpy)
 * [Harmony](https://github.com/pardeike/Harmony)
-* [Beat Saber IPA](https://github.com/nike4613/BeatSaber-IPA-Reloaded)
+* [Beat Saber IPA](https://bsmg.github.io/BeatSaber-IPA-Reloaded/)


### PR DESCRIPTION
The documentation page is more useful than the repository itself, as it holds what modders will actually be using.