### PR TITLE
Warning about Multi-User Oculus feature

### DIFF
--- a/wiki/quest-modding.md
+++ b/wiki/quest-modding.md
@@ -73,7 +73,8 @@ Once it has been successfully installed, make sure you have the latest version o
 :::warning
 Before modding, run Beat Saber once, play a level and immediately fail!
 
-Make sure that you don't use the multi-user feature. Delete any other user except the main account. You can add them later again after completing modding.
+Modding currently does not work if the experimental multi-user feature is in use. You will need to temporarily remove
+all secondary accounts before modding the game. You can add them back later once you have installed your desired mods.
 :::
 
 After running Beat Saber once, open BMBF from unknown sources as the picture below shows.

--- a/wiki/quest-modding.md
+++ b/wiki/quest-modding.md
@@ -72,6 +72,8 @@ Once it has been successfully installed, make sure you have the latest version o
 
 :::warning
 Before modding, run Beat Saber once, play a level and immediately fail!
+
+Make sure that you don't use the multi-user feature. Delete any other user except the main account. You can add them later again after completing modding.
 :::
 
 After running Beat Saber once, open BMBF from unknown sources as the picture below shows.


### PR DESCRIPTION
I've recently spent hours having issue when modding Beat Saber on my Oculus Quest 2.
It turned out that the [Multi-User experimental feature](https://www.oculus.com/blog/gather-your-party-introducing-multi-user-and-app-sharing-on-oculus-quest/) was causing the BS installer to crash.
After installing you can re-add those accounts and the mods run fine.