### PR TITLE
Fix the Unity link and name on Custom Platforms guide

### DIFF
--- a/wiki/models/platforms-guide.md
+++ b/wiki/models/platforms-guide.md
@@ -9,7 +9,7 @@ _Emma's Guide to making Custom Platforms._
 
 ## Project
 Open the current [Custom Platforms Project](https://github.com/affederaffe/CustomPlatforms/releases/latest) with
-[Unity 2018.1.6f1](https://download.unity3d.com/download_unity/57cc34175ccf/Windows64EditorInstaller/UnitySetup64-2018.1.6f1.exe).
+[Unity 2019.4.18f1](https://download.unity3d.com/download_unity/3310a4d4f880/Windows64EditorInstaller/UnitySetup64-2019.4.18f1.exe).
 
 ## First Steps
 ![Custom Platform Script](~@images/models/platforms/CustomPlatformScript.png)


### PR DESCRIPTION
going off the custom platforms readme https://github.com/affederaffe/CustomPlatforms