### PR TITLE
ignore crowdin branch subfolder

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches-ignore:
       - cwdin-backups
+      - 'crowdin/**'
 
 env:
   DEPLOY_URL: 'https://bsmg.wiki/'


### PR DESCRIPTION
update workflow to not run on the staging and history branches for wiki translations.

Improves tracking of what needs to be updated vs not to work around crowdin exporting being dum with ::: formatting.