### PR TITLE
Remove mid anchor mode warning

### DIFF
--- a/wiki/mapping/map-format.md
+++ b/wiki/mapping/map-format.md
@@ -638,16 +638,6 @@ An integer number which represents how the arc curves from the head to the mid p
 * Head and tail `x` are equal; and
 * Head and tail cut direction are equal **OR** their angle difference is 180
 
-:::warning NOTE
-Currently angle difference is NOT an absolute value. These means only half of the opposing direction pairs will
-meet these conditions. These pairs are (head -> tail):
-
-* Down -> Up
-* Right -> Left
-* DownRight -> UpLeft
-* UpRight -> DownLeft
-:::
-
 |`m`|Result|
 |:-------------------:|-------------------|
 |`0`|Straight|


### PR DESCRIPTION
This has been fixed since at least 1.23.0.