### PR TITLE
Update templatr usage

### DIFF
--- a/wiki/modding/quest-mod-dev-intro.md
+++ b/wiki/modding/quest-mod-dev-intro.md
@@ -71,6 +71,8 @@ Once you have setup your environment you can now generate a mod template. The te
 [Lauriethefish](https://github.com/Lauriethefish/quest-mod-template). To start run the following command in Powershell.
 
 ```powershell
+templatr --git https://github.com/Lauriethefish/quest-mod-template <destination>
+# Older templatr versions:
 templatr use Lauriethefish/quest-mod-template
 ```
 


### PR DESCRIPTION
The current latest build of templatr (windows, https://github.com/QuestPackageManager/templatr/actions/runs/4088946923) seems to have changed usage. It no longer has a `use` subcommand, and a full git repository path must be provided to it, along with a destination folder.

```
PS> templatr use Lauriethefish/quest-mod-template
error: unexpected argument 'Lauriethefish/quest-mod-template' found

Usage: templatr.exe --git <GIT> <DEST>

For more information, try '--help'.
```

Using the help command returns:
```
PS> templatr --help
Templatr rust rewrite (implementation not based on the old one)

Usage: templatr.exe --git <GIT> <DEST>

Arguments:
  <DEST>  Destination where template will be copied to. FILES WILL BE OVERWRITTEN

Options:
  -g, --git <GIT>  Link to the git repo, sinonymous with the git clone link
  -h, --help       Print help
  -V, --version    Print version
```

I've updated the wiki to include both this changed syntax as well as the previous syntax, so that people can easily use whatever works for them.