### PR TITLE
Fix git link for templatr 

### DIFF
--- a/wiki/modding/quest-mod-dev-intro.md
+++ b/wiki/modding/quest-mod-dev-intro.md
@@ -71,7 +71,7 @@ Once you have setup your environment you can now generate a mod template. The te
 [Lauriethefish](https://github.com/Lauriethefish/quest-mod-template). To start run the following command in Powershell.
 
 ```powershell
-templatr --git https://github.com/Lauriethefish/quest-mod-template <destination>
+templatr --git https://github.com/Lauriethefish/quest-mod-template.git <destination>
 # Older templatr versions:
 templatr use Lauriethefish/quest-mod-template
 ```


### PR DESCRIPTION
The link in the templatr example is missing “.git” at the end which causes templatr to not work.