### PR TITLE
Tweak zoom image on click behavior

### DIFF
--- a/wiki/.vitepress/theme/custom.css
+++ b/wiki/.vitepress/theme/custom.css
@@ -39,3 +39,22 @@ html.dark .vp-doc :not(pre) > kbd {
 .vp-doc div.center {
   text-align: center;
 }
+
+/**
+ * medium-zoom
+ * -------------------------------------------------------------------------- */
+.medium-zoom-overlay {
+  z-index: var(--vp-z-index-sidebar);
+  transition: opacity 0.5s;
+
+  /* images with transparent backdrop should stay legible */
+  background-color: var(--vp-c-bg);
+}
+
+.medium-zoom--opened .medium-zoom-overlay {
+  opacity: 0.875;
+}
+
+.medium-zoom-image {
+  z-index: calc(var(--vp-z-index-sidebar) + 1);
+}

--- a/wiki/.vitepress/theme/index.ts
+++ b/wiki/.vitepress/theme/index.ts
@@ -20,7 +20,7 @@ export default {
   setup() {
     const route = useRoute()
     const initZoom = () => {
-      mediumZoom('#VPContent img', { background: 'rgba(30, 30, 32, 0.8)' })
+      mediumZoom('#VPContent img')
     }
 
     onMounted(() => {


### PR DESCRIPTION
The original script abused the fact that later elements render over earlier elements without z-index to render the overlay on the top. Moving to vitepress broke this as the new site theme uses z-index. The fix is very straightforward: assign a z-index to the zoom overlay.

Also fixed alongside is contrast problems presented by images with a transparent background, including my own figures. These figures assume a light-colored background in light mode, but unfortunately the dark overlay makes the images difficult to see when zoomed. Changing background color to side background color solves the issue.

Custom styles are moved from inline to custom.css for ease of maintenance.