### PR TITLE
Fix broken link to v2 events

### DIFF
--- a/wiki/mapping/difficulty-format-v3.md
+++ b/wiki/mapping/difficulty-format-v3.md
@@ -493,7 +493,7 @@ Do not set squish factor to 0. This will crash the game.
 }
 ```
 
-See [Events](#events-2) in v2 for information of what these equivalent properties represent.
+See [Events](./difficulty-format-v2.md#events-1) in v2 for information of what these equivalent properties represent.
 
 ### Color Boost Beatmap Events
 


### PR DESCRIPTION
The v3 format page links to v2 events. However, the link is currently incorrect and nothing happens when you click on it.

This commit updates the link to correctly point to the events section on the v2 format page.