### PR TITLE
Updated INFO about latest moddable version in PC Modding

### DIFF
--- a/wiki/pc-modding.md
+++ b/wiki/pc-modding.md
@@ -54,7 +54,7 @@ Instead, you should follow the written guides here on the wiki or seek out help 
 :::
 
 :::tip NOTE
-The latest moddable Beat Saber version for PC is `1.34.2`. You can also downgrade to `1.29.1` if you prefer.
+The latest moddable Beat Saber version for PC is `1.37.0`, however, we recommend using `1.34.2`. You can also downgrade to `1.29.1` if you prefer.
 
 Visit the [Downgrading](#downgrading) section on this page for more information.
 :::

--- a/wiki/pc-modding.md
+++ b/wiki/pc-modding.md
@@ -54,7 +54,7 @@ Instead, you should follow the written guides here on the wiki or seek out help 
 :::
 
 :::tip NOTE
-The latest moddable Beat Saber version for PC is `1.37.0`, however, we recommend using `1.34.2`. You can also downgrade to `1.29.1` if you prefer.
+The latest moddable Beat Saber version for PC is `1.37.0`. You can also downgrade to `1.34.2` or `1.29.1` if you prefer.
 
 Visit the [Downgrading](#downgrading) section on this page for more information.
 :::


### PR DESCRIPTION
Updates the INFO note about the latest moddable version to 1.37, and adds "however, we recommend using 1.34.2."