### PR TITLE
Update playlists sections

### DIFF
--- a/wiki/de/faq/index.md
+++ b/wiki/de/faq/index.md
@@ -38,7 +38,7 @@ Du solltest die Playlist jetzt neben den Custom Levels im Spiel sehen. Der Mod u
 
 ### Quest
 
-Du kannst den [Playlist Editor Pro](https://beatsaberquest.com/bmbf/my-tools/playlist-editor-pro/) verwenden, um die Playlists deiner Quest zu verwalten. Beachte, dass ein Custom Song aufgrund Einschränkungen in BMBF nur einmal im Spiel vorhanden sein kann.
+Du kannst den [QuestSongManager](https://github.com/exelix11/QuestSongManager) verwenden, um die Playlists deiner Quest zu verwalten.
 
 :::warning WARNUNG
 Für Quest User Das Neuladen des Ordners für Custom Songs setzt alle Einstellungen für Playlists zurück.

--- a/wiki/de/quest-modding.md
+++ b/wiki/de/quest-modding.md
@@ -227,7 +227,7 @@ Wenn du keine Songs auf deiner Quest installieren kannst, kannst du sie über de
 Wenn dies nicht funktioniert, [klicke hier](#problembehandlung) für einige Schritte zur Fehlerbehebung.
 
 :::tip TIPP
-Du kannst Playlists auch auf die gleiche Weise herunterladen. Du kannst verschiedene Playlists auf [BeastSaber](https://bsaber.com/category/playlists/) oder verschiedenen Community Discords finden. Du kannst auch deine eigenen erstellen, indem du den [BMBF Manager](https://github.com/ComputerElite/BM#bmbf-manager) oder [Playlist Editor Pro](https://beatsaberquest.com/playlisteditor-pro/) verwendest.
+Du kannst Playlists auch auf die gleiche Weise herunterladen. Du kannst verschiedene Playlists auf [BeatSaver](https://beatsaver.com/playlists) oder verschiedenen Community Discords finden. Du kannst auch deine eigenen erstellen, indem du den [BMBF Manager](https://github.com/ComputerElite/BM#bmbf-manager) oder [QuestSongManager](https://github.com/exelix11/QuestSongManager/) verwendest.
 
 Wenn du eine von deinen erstellte Map testen möchtest, findest du im Abschnitt [Testen auf einer Quest](/de/mapping/#testen-auf-einer-quest) im Mapping Wiki Abschnitt für Schritte zum Verpacken für das Testen!
 :::

--- a/wiki/fr/faq/index.md
+++ b/wiki/fr/faq/index.md
@@ -39,7 +39,7 @@ Vous devriez maintenant voir la playlist à côté de l'album des niveaux person
 ### Quest
 
 **Pour les utilisateurs de Quest :**  
-Vous pouvez utiliser [Playlist Editor Pro](https://beatsaberquest.com/bmbf/my-tools/playlist-editor-pro/) pour gérer les playlists sur votre Quest. Notez qu'un niveau personnalisé ne peut apparaître qu'une seule fois en jeu en raison d'une limitation avec BMBF.
+Vous pouvez utiliser [QuestSongManager](https://github.com/exelix11/QuestSongManager) pour gérer les playlists sur votre Quest.
 
 :::warning ATTENTION
 Pour les utilisateurs de Quest Recharger votre dossier des chansons personnalisées réinitialise toute organisation de playlist.

--- a/wiki/fr/quest-modding.md
+++ b/wiki/fr/quest-modding.md
@@ -236,7 +236,7 @@ Si vous ne pouvez pas installer des custom songs depuis votre Quest, vous pouvez
 Si cela ne fonctionne pas, rendez-vous [ici](#l-interface-web-bmbf-ne-charge-pas) pour corriger le problème.
 
 :::tip ASTUCE
-Vous pouvez télécharger des playlists de la même manière. Vous pouvez en trouver sur [BeastSaber](https://bsaber.com/category/playlists/) ou sur des serveurs Discord de la communauté. Vous pouvez également faire les vôtres avec [BMBF Manager](https://github.com/ComputerElite/BM#bmbf-manager) ou [Playlist Editor Pro](https://beatsaberquest.com/playlisteditor-pro/).
+Vous pouvez télécharger des playlists de la même manière. Vous pouvez en trouver sur [BeatSaver](https://beatsaver.com/playlists) ou sur des serveurs Discord de la communauté. Vous pouvez également faire les vôtres avec [BMBF Manager](https://github.com/ComputerElite/BM#bmbf-manager) ou [QuestSongManager](https://github.com/exelix11/QuestSongManager/).
 
 Si vous voulez tester la map que vous avez créée, consultez la section [Tester sur Oculus Quest](/fr/mapping/#tester-sur-oculus-quest) dans la partie du wiki consacrée au mapping pour savoir comment l'emballer pour la tester !
 :::

--- a/wiki/ja/faq/index.md
+++ b/wiki/ja/faq/index.md
@@ -41,7 +41,7 @@ BeatSaver から手動でマップをダウンロードする場合は、それ�
 
 ### Quest
 
-Quest のプレイリストを管理するには [Playlist Editor Pro](https://beatsaberquest.com/bmbf/my-tools/playlist-editor-pro/) を使用します。 BMBF の機能により、ゲーム内で一度だけカスタムレベルが表示されることに注意してください。
+Quest のプレイリストを管理するには [QuestSongManager](https://github.com/exelix11/QuestSongManager) を使用します。
 
 :::warning Quest ユーザーへの注意
 カスタムソングフォルダを再読み込みすると、すべてのプレイリストの組み合わせがリセットされます。

--- a/wiki/ja/quest-modding.md
+++ b/wiki/ja/quest-modding.md
@@ -218,7 +218,7 @@ Quest 内でマップをインストールできない場合は、mod のイン�
 これがうまくいかない場合は、 [こちら](#bmbf-web-インターフェイスが読み込まれていません) をクリックしてトラブルシューティングの手順に従ってください 。
 
 :::tip
-プレイリストも同様にダウンロードできます。 様々なプレイリストが[Beastsaber](https://bsaber.com/category/playlists/)やディスコードのチャンネルで見つけることができます。 また、 [BMBF Manager](https://github.com/ComputerElite/BM#bmbf-manager)や[Playlist Editor Pro](https://beatsaberquest.com/playlisteditor-pro/)を使って自分自身だけのプレイリストを作ることもできます。
+プレイリストも同様にダウンロードできます。 様々なプレイリストが[BeatSaver](https://beatsaver.com/playlists)やディスコードのチャンネルで見つけることができます。 また、 [BMBF Manager](https://github.com/ComputerElite/BM#bmbf-manager)や[QuestSongManager](https://github.com/exelix11/QuestSongManager)を使って自分自身だけのプレイリストを作ることもできます。
 
 作成したマップをテストしたい場合は、 [Quest でテスト](./mapping/#testing-on-a-quest) の譜面作成セクション内の「テスト用」セクションを参照してください。
 :::

--- a/wiki/nl/faq/index.md
+++ b/wiki/nl/faq/index.md
@@ -38,7 +38,7 @@ Je zou in het spel de afspeellijst naast de custom levels albums moeten kunnen z
 
 ### Quest
 
-Je kan [Playlist Editor Pro](https://beatsaberquest.com/bmbf/my-tools/playlist-editor-pro/) gebruiken om afspeellijsten te beheren op je Quest. Houd er rekening mee dat een zelfgemaakt nummer slechts éénmaling in het spel kan worden weergegeven vanwege een beperking met BMBF.
+Je kan [QuestSongManager](https://github.com/exelix11/QuestSongManager) gebruiken om afspeellijsten te beheren op je Quest.
 
 :::warning WAARSCHUWING
 voor Quest Gebruikers Het herladen van de custom levels, reset alle afspeellijsten.

--- a/wiki/nl/quest-modding.md
+++ b/wiki/nl/quest-modding.md
@@ -236,7 +236,7 @@ Als je geen levels kan installeren vanuit je Quest, kan je dat ook proberen met 
 Als het webinterface niet laad, klik dan [hier](#de-bmbf-webinterface-laad-niet) voor enkele stappen die het probleem kunnen oplossen.
 
 :::tip Hint
-Je kan ook afspeellijsten op dezelfde manier downloaden. Je kan verschillende afspeellijsten vinden op [BeastSaber](https://bsaber.com/category/playlists/) of in verschillende community discords. Je kan ook je eigen afspeellijsten maken met [BMBF Manager](https://github.com/ComputerElite/BM#bmbf-manager) of [Playlist Editor Pro](https://beatsaberquest.com/playlisteditor-pro/).
+Je kan ook afspeellijsten op dezelfde manier downloaden. Je kan verschillende afspeellijsten vinden op [BeatSaver](https://beatsaver.com/playlists) of in verschillende community discords. Je kan ook je eigen afspeellijsten maken met [BMBF Manager](https://github.com/ComputerElite/BM#bmbf-manager) of [QuestSongManager](https://github.com/exelix11/QuestSongManager).
 
 Als je een level wilt testen, bekijk dan de [nummers testen op een Quest](/nl/mapping/#testing-on-a-quest) sectie in de mapping wiki voor stappen voor het klaar maken om nummers te testen!
 :::


### PR DESCRIPTION
-  Replaces the old playlist manager app due to the domain (https://beatsaberquest.com) now leading to a scam site, and now direct people to https://github.com/exelix11/QuestSongManager

- Replace BeastSaber playlists link with BeatSaver as BeastSaber no longer has it's own playlists section

- Remove the warning about songs only appearing once, as it is unnecessary now