### PR TITLE
Update index.md (https://bsmg.wiki/mapping/#testing-on-a-quest)

### DIFF
--- a/wiki/mapping/index.md
+++ b/wiki/mapping/index.md
@@ -404,7 +404,7 @@ When [downloading SideQuest](https://sidequestvr.com/setup-howto), be sure to do
 1. Establish a connection to your Quest from your PC with a USB cable.
 2. Open SideQuest on your PC and click the folder icon on the top right.
    ![SideQuest Files](/.assets/images/beginners-guide/sqfiles.png)
-3. Navigate to `sdcard/ModData/com.beatgames.beatsaber/Mods/SongLoader/CustomWIPLevels`. If this folder does not exist,
+3. Navigate to `sdcard/ModData/com.beatgames.beatsaber/Mods/SongCore/CustomWIPLevels`. If this folder does not exist,
    you can create it yourself.
 4. Upload your WIP song folder from your PC to that folder on your Quest with SideQuest.
    - **NOTE:** You need to upload the actual song folder, not a zip file!


### PR DESCRIPTION
In `index.md`, update `sdcard/ModData/com.beatgames.beatsaber/Mods/SongLoader/CustomWIPLevels` to `sdcard/ModData/com.beatgames.beatsaber/Mods/SongCore/CustomWIPLevels`.

I tried the former on my Quest 2 and SongLoader did not work, but SongCore did, at least for ModsBeforeFriday.

This is my first pull request, so I might have made a mistake.