### PR TITLE
Rewrites latest moddable version note and add 1.37.1 branch in Downgrading

### DIFF
--- a/wiki/pc-modding.md
+++ b/wiki/pc-modding.md
@@ -55,10 +55,8 @@ Instead, you should follow the written guides here on the wiki or seek out help 
 
 :::tip NOTE
 The latest Beat Saber version may not be moddable, in this case you will have to downgrade to the latest moddable version.
-You can check what the latest moddable version is by going to the [BSMG Discord's](https://discord.gg/beatsabermods)
-[modding-announcements channel.](https://discord.com/channels/441805394323439646/612468002243477505)
 
-Visit the [Downgrading](#downgrading) section on this page for more information regarding downgrading.
+Visit the [Downgrading](#downgrading) section on this page for more information.
 :::
 
 ## Installers

--- a/wiki/pc-modding.md
+++ b/wiki/pc-modding.md
@@ -224,7 +224,7 @@ Click on these links corresponding to where you own the game to see the tutorial
 
 ### Legacy Branch
 
-If you want to downgrade to `1.34.2` or `1.29.1` you can use the legacy branch method.
+If you want to downgrade to `1.37.1`, `1.34.2`, or `1.29.1` you can use the legacy branch method.
 
 #### Steam Users
 
@@ -235,7 +235,7 @@ If you want to downgrade to `1.34.2` or `1.29.1` you can use the legacy branch m
 2. Right click Beat Saber in the game library
 3. Select Properties
 4. Select Betas in the window
-5. Select either the `1.34.2_legacy` or the `legacy1.29.1_unity_ver2019.4.28f1` branch
+5. Select either the `legacy1.37.1_unity_v2021.3.16f1`, `1.34.2_legacy` or the `legacy1.29.1_unity_ver2019.4.28f1` branch
 6. Exit the window
 7. Let the download complete then run the game once
 8. Follow the regular modding process
@@ -251,7 +251,7 @@ If you want to downgrade to `1.34.2` or `1.29.1` you can use the legacy branch m
 2. Go to the Beat Saber store page
 3. Scroll down to `Versions + Release Notes`
 4. Click on the word `(LIVE)` next to the current version number
-5. Select either the `1.34.2_legacy` or the `legacy1.29.1_unity_ver2019.4.28f1: 1.29.1_4575554838` branch
+5. Select either the `legacy1.37.1_unity_v2021.3.16f1`, `1.34.2_legacy` or the `legacy1.29.1_unity_ver2019.4.28f1` branch
 6. Let the download complete and run the game once
 7. Follow the regular modding process
 

--- a/wiki/pc-modding.md
+++ b/wiki/pc-modding.md
@@ -54,9 +54,10 @@ Instead, you should follow the written guides here on the wiki or seek out help 
 :::
 
 :::tip NOTE
-The latest moddable Beat Saber version for PC is `1.37.0`. You can also downgrade to `1.34.2` or `1.29.1` if you prefer.
+The latest Beat Saber version may not be moddable, in this case you will have to downgrade to the latest moddable version
+You can check what the latest moddable version is by going to the [BSMG Discord's](https://discord.gg/beatsabermods) [modding-announcements channel.](https://discord.com/channels/441805394323439646/612468002243477505)
 
-Visit the [Downgrading](#downgrading) section on this page for more information.
+Visit the [Downgrading](#downgrading) section on this page for more information regarding downgrading.
 :::
 
 ## Installers

--- a/wiki/pc-modding.md
+++ b/wiki/pc-modding.md
@@ -54,8 +54,9 @@ Instead, you should follow the written guides here on the wiki or seek out help 
 :::
 
 :::tip NOTE
-The latest Beat Saber version may not be moddable, in this case you will have to downgrade to the latest moddable version
-You can check what the latest moddable version is by going to the [BSMG Discord's](https://discord.gg/beatsabermods) [modding-announcements channel.](https://discord.com/channels/441805394323439646/612468002243477505)
+The latest Beat Saber version may not be moddable, in this case you will have to downgrade to the latest moddable version.
+You can check what the latest moddable version is by going to the [BSMG Discord's](https://discord.gg/beatsabermods)
+[modding-announcements channel.](https://discord.com/channels/441805394323439646/612468002243477505)
 
 Visit the [Downgrading](#downgrading) section on this page for more information regarding downgrading.
 :::


### PR DESCRIPTION
Rewrites the latest moddable version to say "The latest Beat Saber version may not be moddable", and adds a link to the modding-announcements channel for the purpose of checking if the latest version is moddable. This is to fix an inconsistency of having to update this every time a Beat Saber update is released.