### PR TITLE
Add 1.37.2 issues to deprecation notice in ModAssistant

### DIFF
--- a/wiki/pc-modding.md
+++ b/wiki/pc-modding.md
@@ -84,7 +84,8 @@ Get it on [affederaffe's GitHub](https://github.com/affederaffe/BeatSaberModMana
 ### ModAssistant
 
 :::warning
-ModAssistant will be phased out in the future and is no longer recommended.  
+ModAssistant has broken on versions `1.37.2` and above, and because of this and other issues, ModAssistant will be
+phased out in the future and is no longer recommended.  
 Consider switching to one of the options above instead!
 :::
 

--- a/wiki/pc-modding.md
+++ b/wiki/pc-modding.md
@@ -73,6 +73,12 @@ An all-in-one tool that lets you easily manage BeatSaber versions, maps, mods, a
 
 ### BeatSaberModManager
 
+:::warning DEPRECATION
+BeatSaberModManager has broken on versions `1.37.2` and above, and because of this,
+BeatSaberModManager will be phased out in the future and is no longer recommended.  
+Consider switching to [BSManager](#bsmanager) instead!
+:::
+
 \***\*Run the game at least once\*\*** before trying to mod the game! This applies to reinstalling your game too.
 
 Yet another mod installer for Beat Saber, heavily inspired by ModAssistant.
@@ -83,10 +89,10 @@ Get it on [affederaffe's GitHub](https://github.com/affederaffe/BeatSaberModMana
 
 ### ModAssistant
 
-:::warning
+:::warning DEPRECATION
 ModAssistant has broken on versions `1.37.2` and above, and because of this and other issues, ModAssistant will be
 phased out in the future and is no longer recommended.  
-Consider switching to one of the options above instead!
+Consider switching to [BSManager](#bsmanager) instead!
 :::
 
 A simple Beat Saber Mod Installer similar to the mod manager, but with additional features such as mod removal

--- a/wiki/pc-modding.md
+++ b/wiki/pc-modding.md
@@ -84,7 +84,8 @@ Get it on [affederaffe's GitHub](https://github.com/affederaffe/BeatSaberModMana
 ### ModAssistant
 
 :::warning NOTICE  
-ModAssistant is no longer recommended and being phased out as it cannot reliably mod Beat Saber versions `1.37.2` and above.  
+ModAssistant is no longer recommended and being phased out as it cannot reliably mod Beat Saber versions
+`1.37.2` and above.  
 Consider switching to one of the options above instead!
 :::
 

--- a/wiki/pc-modding.md
+++ b/wiki/pc-modding.md
@@ -73,12 +73,6 @@ An all-in-one tool that lets you easily manage BeatSaber versions, maps, mods, a
 
 ### BeatSaberModManager
 
-:::warning DEPRECATION
-BeatSaberModManager has broken on versions `1.37.2` and above, and because of this,
-BeatSaberModManager will be phased out in the future and is no longer recommended.  
-Consider switching to [BSManager](#bsmanager) instead!
-:::
-
 \***\*Run the game at least once\*\*** before trying to mod the game! This applies to reinstalling your game too.
 
 Yet another mod installer for Beat Saber, heavily inspired by ModAssistant.
@@ -92,7 +86,7 @@ Get it on [affederaffe's GitHub](https://github.com/affederaffe/BeatSaberModMana
 :::warning DEPRECATION
 ModAssistant has broken on versions `1.37.2` and above, and because of this and other issues, ModAssistant will be
 phased out in the future and is no longer recommended.  
-Consider switching to [BSManager](#bsmanager) instead!
+Consider switching to one of the options above instead!
 :::
 
 A simple Beat Saber Mod Installer similar to the mod manager, but with additional features such as mod removal

--- a/wiki/pc-modding.md
+++ b/wiki/pc-modding.md
@@ -83,9 +83,8 @@ Get it on [affederaffe's GitHub](https://github.com/affederaffe/BeatSaberModMana
 
 ### ModAssistant
 
-:::warning DEPRECATION
-ModAssistant has broken on versions `1.37.2` and above, and because of this and other issues, ModAssistant will be
-phased out in the future and is no longer recommended.  
+:::warning NOTICE  
+ModAssistant is no longer recommended and being phased out as it cannot reliably mod Beat Saber versions `1.37.2` and above.  
 Consider switching to one of the options above instead!
 :::
 


### PR DESCRIPTION
Adds the issues with 1.37.2 to ModAssistant, and add a deprecation notice to BSMM's section, as that is broken as well on 1.37.2 and above.

Preview of these changes are found [here.](https://overlappingd.github.io/bsmg-wiki/pc-modding.html#modassistant)