### PR TITLE
Add tip for using BeatTimer in basic audio mapping guides

### DIFF
--- a/wiki/de/mapping/basic-audio.md
+++ b/wiki/de/mapping/basic-audio.md
@@ -19,11 +19,6 @@ Auf dieser Seite finden sowohl neue als auch erfahrene Mapper allgemeine Empfehl
 - Die Schritte 1-3 **MÜSSEN** abgeschlossen sein, bevor du mit dem Mapping beginnst, sonst ist deine Audio nicht mehr synchron und kann einen [_Hot Start_](./glossary.md#h) haben.
 - Die Verwendung von Online-Websites zur Konvertierung von Audio in `.ogg` kann dazu führen, dass deine Audiodatei als ungültig behandelt wird und nicht vom Spiel geladen werden kann! Das Bearbeiten und Exportieren von [Audacity](https://www.audacityteam.org/) ist der einfachste Weg, um sicherzustellen, dass deine Audiodatei wie erwartet funktioniert.
   :::
-  
-::: tip TIPP
-Nutze [BeatTimer](https://beat-timer.webry.com/), um die Schritte 1-3 auf einmal durchzuführen, ohne zusätzliche
- Software installieren zu müssen.
-:::
 
 1. Lade [Audacity](https://www.audacityteam.org/) herunter und installiere es
    - Installiere optional das [ffmpeg für Windows](https://manual.audacityteam.org/man/installing_ffmpeg_for_windows.html) Addon, um zusätzliche Dateitypen wie `.aac` oder `.m4a` aus iTunes zu öffnen.
@@ -33,6 +28,11 @@ Nutze [BeatTimer](https://beat-timer.webry.com/), um die Schritte 1-3 auf einmal
 **Jederzeit vor dem Hochladen:**  
 4. [Prüfe deine Song-Lautstärke](#songlautstarke-prufen) und stelle sie je nach Bedarf [Lauter](#mach-deinen-song-lauter) oder [Leiser](#mache-deinen-song-softer) ein.  
 5. Überprüfe die Länge deines Song-Outros und [kürze es bei Bedarf](#trimmen-des-outros).
+
+::: tip TIPP
+Nutze [BeatTimer](https://beat-timer.webry.com/), um die Schritte 1-3 auf einmal durchzuführen, ohne zusätzliche
+ Software installieren zu müssen.
+:::
 
 ## Songauswahl für neue Mapper
 

--- a/wiki/de/mapping/basic-audio.md
+++ b/wiki/de/mapping/basic-audio.md
@@ -19,6 +19,10 @@ Auf dieser Seite finden sowohl neue als auch erfahrene Mapper allgemeine Empfehl
 - Die Schritte 1-3 **MÜSSEN** abgeschlossen sein, bevor du mit dem Mapping beginnst, sonst ist deine Audio nicht mehr synchron und kann einen [_Hot Start_](./glossary.md#h) haben.
 - Die Verwendung von Online-Websites zur Konvertierung von Audio in `.ogg` kann dazu führen, dass deine Audiodatei als ungültig behandelt wird und nicht vom Spiel geladen werden kann! Das Bearbeiten und Exportieren von [Audacity](https://www.audacityteam.org/) ist der einfachste Weg, um sicherzustellen, dass deine Audiodatei wie erwartet funktioniert.
   :::
+  
+::: tip TIPP
+Nutze [BeatTimer](https://beat-timer.webry.com/), um die Schritte 1-3 auf einmal durchzuführen, ohne zusätzliche Software installieren zu müssen.
+:::
 
 1. Lade [Audacity](https://www.audacityteam.org/) herunter und installiere es
    - Installiere optional das [ffmpeg für Windows](https://manual.audacityteam.org/man/installing_ffmpeg_for_windows.html) Addon, um zusätzliche Dateitypen wie `.aac` oder `.m4a` aus iTunes zu öffnen.

--- a/wiki/de/mapping/basic-audio.md
+++ b/wiki/de/mapping/basic-audio.md
@@ -21,7 +21,8 @@ Auf dieser Seite finden sowohl neue als auch erfahrene Mapper allgemeine Empfehl
   :::
   
 ::: tip TIPP
-Nutze [BeatTimer](https://beat-timer.webry.com/), um die Schritte 1-3 auf einmal durchzuführen, ohne zusätzliche Software installieren zu müssen.
+Nutze [BeatTimer](https://beat-timer.webry.com/), um die Schritte 1-3 auf einmal durchzuführen, ohne zusätzliche
+ Software installieren zu müssen.
 :::
 
 1. Lade [Audacity](https://www.audacityteam.org/) herunter und installiere es

--- a/wiki/mapping/basic-audio.md
+++ b/wiki/mapping/basic-audio.md
@@ -24,6 +24,10 @@ that can be done at any time, if they're needed.
   your audio file works as expected.
   :::
 
+::: tip
+Use [BeatTimer](https://beat-timer.webry.com/) to do steps 1-3 in one go more easily without needing to install any additional software.
+:::
+
 1. Download and Install [Audacity](https://www.audacityteam.org/)
    - Optionally install the [ffmpeg for windows](https://manual.audacityteam.org/man/installing_ffmpeg_for_windows.html)
      addon to open additional file types such as `.aac` or `.m4a` from iTunes.

--- a/wiki/mapping/basic-audio.md
+++ b/wiki/mapping/basic-audio.md
@@ -24,11 +24,6 @@ that can be done at any time, if they're needed.
   your audio file works as expected.
   :::
 
-::: tip
-Use [BeatTimer](https://beat-timer.webry.com/) to do steps 1-5 in one go more easily without needing to install any
-additional software.
-:::
-
 1. Download and Install [Audacity](https://www.audacityteam.org/)
    - Optionally install the [ffmpeg for windows](https://manual.audacityteam.org/man/installing_ffmpeg_for_windows.html)
      addon to open additional file types such as `.aac` or `.m4a` from iTunes.
@@ -39,6 +34,11 @@ additional software.
 4. [Check your song volume](#check-song-volume) and make it [louder](#making-your-song-louder) or
 [softer](#making-your-song-softer) as needed  
 5. Check the length of your song outro and [trim it](#trimming-the-outro) if needed
+
+::: tip NOTE
+Alternatively you can use [BeatTimer](https://beat-timer.webry.com/) to setup your audio without needing
+to install any additional software.
+:::
 
 ## Song Selection for New Mappers
 

--- a/wiki/mapping/basic-audio.md
+++ b/wiki/mapping/basic-audio.md
@@ -25,7 +25,8 @@ that can be done at any time, if they're needed.
   :::
 
 ::: tip
-Use [BeatTimer](https://beat-timer.webry.com/) to do steps 1-3 in one go more easily without needing to install any additional software.
+Use [BeatTimer](https://beat-timer.webry.com/) to do steps 1-3 in one go more easily without needing to install any
+additional software.
 :::
 
 1. Download and Install [Audacity](https://www.audacityteam.org/)

--- a/wiki/mapping/basic-audio.md
+++ b/wiki/mapping/basic-audio.md
@@ -25,7 +25,7 @@ that can be done at any time, if they're needed.
   :::
 
 ::: tip
-Use [BeatTimer](https://beat-timer.webry.com/) to do steps 1-3 in one go more easily without needing to install any
+Use [BeatTimer](https://beat-timer.webry.com/) to do steps 1-5 in one go more easily without needing to install any
 additional software.
 :::
 


### PR DESCRIPTION
Some time ago I created a website that tries to take all the work out of syncing audio for mapping. I made the project for fun and to test my dev skills. Since then people loved it and some are using it regularly for new maps. For the future I also plan on adding audio normalization so that BeatTimer takes away step 4 aswell (see changes). *(Edit: Volume Normalization was added)*

The application works completely locally using ffmpeg-wasm so no login or hosting is needed on my part. It would be a shame if people don't know about it and lose the time benefit. Or for some installing Audacity could also be a challenge stopping them from mapping (audio-synced maps). So I propose to add that tip into the docs and would be happy if the work helps more people out there.

This is the repo of the website (also mentioned in help section on top left): [GitHub Repository](https://github.com/web-dev-sam/beat-timer) ([Website](https://beat-timer.webry.com/)). To test it you can simply use the example button on top right. 