### PR TITLE
Fixes 404 Error in "Contact Us" URL

### DIFF
--- a/wiki/.vitepress/config/en.ts
+++ b/wiki/.vitepress/config/en.ts
@@ -12,7 +12,7 @@ export const en = defineConfig({
       { text: 'Home', link: '/' },
       { text: 'Beginners Guide', link: '/beginners-guide.md' },
       { text: 'BSMG Discord', link: 'https://discord.gg/beatsabermods' },
-      { text: 'Contact Us', link: './contact-us.md' },
+      { text: 'Contact Us', link: '/contact-us.md' },
     ],
 
     footer: {


### PR DESCRIPTION
With the period in the URL, it causes a 404 Error to occur.

For example, if you are nested at `https://bsmg.wiki/mapping/#additional-mapping-tools`, or even just `https://bsmg.wiki/mapping/`, clicking on the Contact Us will direct you to `https://bsmg.wiki/mapping/contact-us` which doesn't exist.