### PR TITLE
docs: add beatsketch to mapping tools

### DIFF
--- a/wiki/mapping/index.md
+++ b/wiki/mapping/index.md
@@ -232,7 +232,7 @@ this to succeed.
 
 - [ArcViewer](https://allpoland.github.io/ArcViewer/) by **AllPoland**  
   An open source 3D Beat Saber map previewer, designed to give users an accurate representation of Beat Saber maps.
-- [BeatSketch](https://beatsketch.github.io)
+- [BeatSketch](https://beatsketch.github.io) (Beta)
   A free and open source VR-based map maker, to create a first map draft by playing it in VR, with your movements converted into blocks
 - [+1 Rabbit's Mapping Tools](https://skystudioapps.com/mapping-tools/) by **+1 Rabbit**  
   A suite of tools for mappers that includes:

--- a/wiki/mapping/index.md
+++ b/wiki/mapping/index.md
@@ -233,7 +233,7 @@ this to succeed.
 - [ArcViewer](https://allpoland.github.io/ArcViewer/) by **AllPoland**  
   An open source 3D Beat Saber map previewer, designed to give users an accurate representation of Beat Saber maps.
 - [BeatSketch](https://beatsketch.github.io) (Beta)
-  A free and open source VR-based map maker, to create a first map draft by playing it in VR, with your movements converted into blocks
+  A free and open source VR-based map maker, to create a first map draft by playing it in VR
 - [+1 Rabbit's Mapping Tools](https://skystudioapps.com/mapping-tools/) by **+1 Rabbit**  
   A suite of tools for mappers that includes:
   - **Schema Fixer:** Easily fix maps made in Mediocre Mapper Mk4.1 and Mk5 for upload to BeatSaver.

--- a/wiki/mapping/index.md
+++ b/wiki/mapping/index.md
@@ -232,6 +232,8 @@ this to succeed.
 
 - [ArcViewer](https://allpoland.github.io/ArcViewer/) by **AllPoland**  
   An open source 3D Beat Saber map previewer, designed to give users an accurate representation of Beat Saber maps.
+- [BeatSketch](https://beatsketch.github.io)
+  A free and open source VR-based map maker, to create a first map draft by playing it in VR, with your movements converted into blocks
 - [+1 Rabbit's Mapping Tools](https://skystudioapps.com/mapping-tools/) by **+1 Rabbit**  
   A suite of tools for mappers that includes:
   - **Schema Fixer:** Easily fix maps made in Mediocre Mapper Mk4.1 and Mk5 for upload to BeatSaver.


### PR DESCRIPTION
Adds a link to BeatSketch, a VR based map-maker.
It is currently in late alpha stage, with a first beta release planned for tomorrow.
See https://github.com/BeatSketch for the organization and https://beatsketch.github.io for the website.
The website will see a lot of changes still, but we would like to see some people try BeatSketch so we can get more bug testing.

In addition, I am not sure where you would like to have this added, because it does only partially make sense with the other full-blown editors, and the same applies to the mapping tools